### PR TITLE
Feat: Enhance project type detection and verify GitHub alignment

### DIFF
--- a/docs/GITHUB_LANGUAGE_COMPARISON.md
+++ b/docs/GITHUB_LANGUAGE_COMPARISON.md
@@ -1,0 +1,516 @@
+<!--
+SPDX-FileCopyrightText: 2024 Linux Foundation
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# GitHub Language Comparison Tool
+
+This document describes the GitHub language comparison tool that helps align our local project type detection with GitHub's language detection (powered by Linguist).
+
+## Overview
+
+The `compare_github_languages.py` script fetches language/project type data from GitHub for all repositories in an organization and compares it with our local detection results. This helps identify:
+
+- **Gaps** - Languages GitHub detects that we miss
+- **Mismatches** - Different primary language/type classifications
+- **Alignment opportunities** - Where we can improve our detection logic
+- **Success metrics** - How well our detection matches GitHub's
+
+## Why Compare with GitHub?
+
+GitHub uses [Linguist](https://github.com/github-linguist/linguist), a sophisticated language detection library that:
+
+- Analyzes file content, not just extensions
+- Uses a comprehensive database of language definitions
+- Has weighted scoring for different file types
+- Ignores vendored code, generated files, and documentation
+- Is battle-tested across millions of repositories
+
+Aligning with GitHub's detection ensures:
+
+1. **Consistency** - Users see the same language classifications on GitHub and in reports
+2. **Accuracy** - Leverage GitHub's proven detection algorithms
+3. **Completeness** - Detect all languages GitHub recognizes
+
+## Prerequisites
+
+1. **GitHub Personal Access Token** with `repo` or `public_repo` scope
+   - Create at: <https://github.com/settings/tokens>
+   - For public repos only, use `public_repo` scope
+   - For private repos, use `repo` scope
+
+2. **Python dependencies**:
+
+   ```bash
+   pip install httpx
+   ```
+
+3. **Optional: Cloned repositories** for local analysis
+   - If you want to compare local detection, clone repos first
+   - Or use existing cloned repositories
+
+## Usage
+
+### Basic: GitHub-Only Analysis
+
+Fetch language data from GitHub without local comparison:
+
+```bash
+python scripts/compare_github_languages.py \
+    --org onap \
+    --github-token $GITHUB_TOKEN
+```
+
+This will:
+
+- Fetch all repositories in the organization
+- Get language statistics for each repository
+- Show GitHub's language detection results
+- Save to JSON if `--output` is specified
+
+### Full Comparison with Local Detection
+
+Compare GitHub's detection with our local analysis:
+
+```bash
+python scripts/compare_github_languages.py \
+    --org onap \
+    --github-token $GITHUB_TOKEN \
+    --repos-path ./repos
+```
+
+This will:
+
+- Fetch GitHub language data
+- Analyze local repositories in `./repos`
+- Compare the results
+- Generate detailed comparison report
+
+### Save Detailed Results
+
+Save full comparison data to JSON:
+
+```bash
+python scripts/compare_github_languages.py \
+    --org onap \
+    --github-token $GITHUB_TOKEN \
+    --repos-path ./repos \
+    --output comparison_results.json
+```
+
+### With Debug Logging
+
+Get detailed logging output:
+
+```bash
+python scripts/compare_github_languages.py \
+    --org onap \
+    --github-token $GITHUB_TOKEN \
+    --repos-path ./repos \
+    --log-level DEBUG
+```
+
+## Output Format
+
+### Console Report
+
+The script generates a human-readable report with:
+
+```text
+================================================================================
+GitHub vs Local Language Detection Comparison
+================================================================================
+
+Summary:
+  Total GitHub repos: 245
+  Analyzed locally: 183
+  Exact matches: 156
+  Partial matches: 8
+  Complete mismatches: 19
+  No local data: 62
+```
+
+Match Percentages:
+  Exact matches: 71.7%
+  Partial matches: 15.7%
+  Mismatches: 12.6%
+
+Languages with Good Agreement:
+  (GitHub primary language matched our detection)
+  Python: 89 repos
+  Java: 42 repos
+  JavaScript: 18 repos
+  Go: 12 repos
+  ...
+
+Language Detection Gaps:
+  (GitHub detected but we missed as primary)
+  Shell: 8 repos
+  Makefile: 5 repos
+  Dockerfile: 3 repos
+  ...
+
+Sample Mismatches (first 10):
+  Repository: example-repo
+    GitHub primary: Python
+    Our primary: Dockerfile
+    GitHub languages: Python, Dockerfile, Shell
+    Our types: Dockerfile, Python
+  ...
+
+```text
+
+### JSON Output
+
+The `--output` file contains detailed data:
+
+```json
+{
+  "github_data": {
+    "repo-name": {
+      "full_name": "org/repo-name",
+      "html_url": "https://github.com/org/repo-name",
+      "github_primary_language": "Python",
+      "languages": {
+        "Python": 125000,
+        "Shell": 3500,
+        "Dockerfile": 500
+      },
+      "calculated_primary": "Python",
+      "total_bytes": 129000,
+      "archived": false,
+      "fork": false
+    }
+  },
+  "local_data": {
+    "repo-name": {
+      "detected_types": ["Python", "Dockerfile", "Shell"],
+      "primary_type": "Python",
+      "details": [
+        {
+          "type": "Python",
+          "files": ["setup.py", "main.py"],
+          "confidence": 2
+        }
+      ]
+    }
+  },
+  "comparison": {
+    "total_repos": 245,
+    "analyzed_locally": 198,
+    "matches": [...],
+    "mismatches": [...],
+    "statistics": {...}
+  }
+}
+```
+
+## Understanding the Results
+
+### Match Types
+
+1. **Exact Match**
+   - GitHub's primary language matches our primary type
+   - Best case scenario
+   - Example: GitHub=Python, Our=Python
+
+2. **Partial Match**
+   - GitHub's primary is in our detected types, but not primary
+   - We detected it, but prioritized differently
+   - Example: GitHub=Python, Our primary=Dockerfile, detected=[Dockerfile, Python]
+
+3. **Complete Mismatch**
+   - GitHub's primary language not in our detected types
+   - Indicates missing detection or significant discrepancy
+   - Example: GitHub=Python, Our=[Java, Dockerfile]
+
+### Interpreting Statistics
+
+**High Exact Match %** (>70%)
+
+- Good alignment with GitHub
+- Minor tweaks may improve further
+
+**High Partial Match %** (>20%)
+
+- Detection works but prioritization differs
+- Review confidence scoring logic
+- Consider GitHub's byte-count weighting
+
+**High Mismatch %** (>15%)
+
+- Significant detection gaps
+- Add missing language patterns
+- Review file detection logic
+
+## Common Issues and Solutions
+
+### Issue: Low Exact Match Percentage
+
+**Causes:**
+
+- Confidence scoring differs from GitHub's byte-count approach
+- Missing file patterns for certain languages
+- Over-detection of infrastructure files (Dockerfile, Makefile)
+
+**Solutions:**
+
+1. Adjust confidence scoring to weight actual code files more heavily
+2. Add missing file extensions from gaps report
+3. Consider ignoring or de-prioritizing infrastructure files
+
+### Issue: "Shell" or "Makefile" as GitHub Primary
+
+**Cause:**
+
+- Repository has more build/script files than application code
+- GitHub prioritizes by byte count
+
+**Solution:**
+
+- This might be correct (e.g., shell script projects)
+- Or adjust confidence to favor application code over build scripts
+
+### Issue: Language Gaps in Report
+
+**Cause:**
+
+- We don't detect certain languages GitHub recognizes
+
+**Solution:**
+
+1. Check if language is in our `project_types` dictionary
+2. Add missing patterns from GitHub Linguist
+3. Add tests for the new language
+
+### Issue: Different Primary for Multi-Language Repos
+
+**Cause:**
+
+- Complex repos (e.g., Python backend + React frontend)
+- Different weighting strategies
+
+**Solution:**
+
+- Document expected behavior
+- May be acceptable divergence
+- Or adjust confidence scoring
+
+## Improving Detection Alignment
+
+### Step 1: Analyze Gap Report
+
+Look at "Language Detection Gaps" section:
+
+```text
+Language Detection Gaps:
+  Shell: 8 repos
+  Makefile: 5 repos
+  CMake: 3 repos
+```
+
+### Step 2: Check if We Detect These
+
+For each language in gaps:
+
+- Check if it's in `src/gerrit_reporting_tool/features/registry.py`
+- If missing, add it with appropriate patterns
+- If present, check if patterns match GitHub's
+
+### Step 3: Review Mismatch Samples
+
+Examine specific mismatches:
+
+- Clone the repository
+- Look at file structure
+- Understand why GitHub chose its primary
+- Adjust our detection logic accordingly
+
+### Step 4: Adjust Confidence Scoring
+
+Consider GitHub's approach:
+
+- They use byte counts (more code = higher weight)
+- We use file counts (more files = higher weight)
+
+You might want to:
+
+- Weight by file size instead of count
+- Prioritize actual source code over config files
+- De-prioritize generated files
+
+### Step 5: Add Tests
+
+For each improved detection:
+
+- Add test in `tests/unit/test_project_type_detection.py`
+- Verify against known repositories
+- Document expected behavior
+
+## ONAP-Specific Considerations
+
+### Repository Structure
+
+ONAP repositories often have:
+
+- Multiple languages (Python, Java, Go)
+- Heavy use of YAML, JSON for configuration
+- Docker, Kubernetes manifests
+- Shell scripts for tooling
+- Documentation in reStructuredText
+
+### Expected Patterns
+
+Based on ONAP's architecture:
+
+- **Python**: ML/AI components, tooling, testing
+- **Java**: Core components, SDN-C, APPC
+- **Go**: Cloud-native services, integration
+- **JavaScript/TypeScript**: UI components (Portal, SDC)
+- **Dockerfile**: Container definitions (very common)
+
+### Comparison Goals
+
+For ONAP, aim for:
+
+- 70%+ exact match rate
+- <15% complete mismatch rate
+- Good agreement on: Python, Java, Go, JavaScript
+
+## Example Workflow
+
+### 1. Initial Analysis
+
+```bash
+# Fetch GitHub data
+python scripts/compare_github_languages.py \
+    --org onap \
+    --github-token $GITHUB_TOKEN \
+    --output github_baseline.json
+```
+
+### 2. Clone Representative Repos
+
+```bash
+# Clone a subset for testing
+mkdir -p repos
+cd repos
+git clone https://github.com/onap/policy-engine
+git clone https://github.com/onap/portal
+git clone https://github.com/onap/so
+# ... etc
+cd ..
+```
+
+### 3. Run Comparison
+
+```bash
+python scripts/compare_github_languages.py \
+    --org onap \
+    --github-token $GITHUB_TOKEN \
+    --repos-path ./repos \
+    --output comparison.json
+```
+
+### 4. Analyze Results
+
+Review the report and identify top mismatches.
+
+### 5. Improve Detection
+
+Edit `src/gerrit_reporting_tool/features/registry.py` based on gaps.
+
+### 6. Test Changes
+
+```bash
+pytest tests/unit/test_project_type_detection.py -v
+```
+
+### 7. Re-run Comparison
+
+```bash
+python scripts/compare_github_languages.py \
+    --org onap \
+    --github-token $GITHUB_TOKEN \
+    --repos-path ./repos
+```
+
+### 8. Verify Improvement
+
+Compare statistics before and after changes.
+
+## API Rate Limits
+
+GitHub API has rate limits:
+
+- **Authenticated**: 5,000 requests/hour
+- **Unauthenticated**: 60 requests/hour
+
+The script makes:
+
+- 1 request per page of repos (~1-3 for most orgs)
+- 1 request per repository for languages
+
+For ONAP (~245 repos):
+
+- Total requests: ~250
+- Well within rate limits
+- Runtime: ~2-3 minutes
+
+## Security Considerations
+
+1. **Token Security**
+   - Never commit tokens to git
+   - Use environment variables
+   - Rotate tokens regularly
+
+2. **Token Permissions**
+   - Use minimal required scope
+   - For public repos: `public_repo`
+   - For private repos: `repo`
+
+3. **Data Privacy**
+   - GitHub data is public for public repos
+   - Don't expose private repo data
+   - Be careful with output files
+
+## Troubleshooting
+
+### Error: "httpx package is required"
+
+```bash
+pip install httpx
+```
+
+### Error: "No module named 'gerrit_reporting_tool'"
+
+Run from repository root or install package:
+
+```bash
+pip install -e .
+```
+
+### Error: "401 Unauthorized"
+
+- Check token is valid
+- Verify token has required permissions
+- Check token hasn't expired
+
+### Error: "403 Rate Limit Exceeded"
+
+- Wait for rate limit to reset
+- Check current limits: `curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/rate_limit`
+
+### Warning: "No local data"
+
+- Ensure `--repos-path` points to correct directory
+- Verify repositories are cloned
+- Check directory names match GitHub repo names
+
+## Further Reading
+
+- [GitHub Linguist Documentation](https://github.com/github-linguist/linguist)
+- [GitHub Languages API](https://docs.github.com/en/rest/repos/repos#list-repository-languages)
+- [GitHub Rate Limiting](https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api)
+- [Project Type Detection Documentation](PROJECT_TYPE_DETECTION.md)

--- a/scripts/README_COMPARE_LANGUAGES.md
+++ b/scripts/README_COMPARE_LANGUAGES.md
@@ -1,0 +1,393 @@
+<!--
+SPDX-FileCopyrightText: 2024 Linux Foundation
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quick Start: GitHub Language Comparison
+
+This guide shows you how to compare GitHub's language detection with our local project type detection for ONAP repositories.
+
+## Prerequisites
+
+1. **GitHub Token**: Create a personal access token at <https://github.com/settings/tokens>
+   - For public repos (ONAP), select the `public_repo` scope
+   - Save the token securely
+
+2. **Install Dependencies**:
+
+   ```bash
+   pip install httpx
+   pip install -e .
+   ```
+
+## Quick Examples
+
+### Example 1: Fetch GitHub Language Data
+
+Get language statistics from GitHub for all ONAP repositories:
+
+```bash
+export GITHUB_TOKEN="your_token_here"
+
+python scripts/compare_github_languages.py \
+    --org onap \
+    --output onap_github_languages.json
+```
+
+**Output**: Console report + JSON file with all GitHub language data
+
+**Use case**: Quick overview of what languages GitHub detects across ONAP
+
+---
+
+### Example 2: Compare with Local Repositories
+
+If you have ONAP repos cloned locally, compare GitHub's detection with ours:
+
+```bash
+export GITHUB_TOKEN="your_token_here"
+
+python scripts/compare_github_languages.py \
+    --org onap \
+    --repos-path /path/to/onap/repos \
+    --output onap_comparison.json
+```
+
+**Output**: Detailed comparison report + JSON with alignment analysis
+
+**Use case**: Identify where our detection differs from GitHub's
+
+---
+
+### Example 3: Debug Specific Issues
+
+Get detailed logging to troubleshoot detection problems:
+
+```bash
+export GITHUB_TOKEN="your_token_here"
+
+python scripts/compare_github_languages.py \
+    --org onap \
+    --repos-path ./repos \
+    --log-level DEBUG \
+    --output debug_comparison.json
+```
+
+**Output**: Verbose logging + full comparison data
+
+**Use case**: Investigate why specific repos have mismatched classifications
+
+---
+
+## Understanding the Output
+
+### Console Report
+
+```text
+================================================================================
+GitHub vs Local Language Detection Comparison
+================================================================================
+
+Summary:
+  Total GitHub repos: 245
+  Analyzed locally: 198
+  Exact matches: 142
+  Partial matches: 31
+  Complete mismatches: 25
+  No local data: 47
+
+Match Percentages:
+  Exact matches: 71.7%        ✓ Good alignment
+  Partial matches: 15.7%      ⚠ Detection works, prioritization differs
+  Mismatches: 12.6%           ✗ Need improvement
+
+Languages with Good Agreement:
+  Python: 89 repos            ✓ Our Python detection aligns well
+  Java: 42 repos              ✓ Our Java detection aligns well
+  JavaScript: 18 repos        ✓ Our JavaScript detection aligns well
+
+Language Detection Gaps:
+  Shell: 8 repos              ⚠ We're missing Shell as primary in these repos
+  Makefile: 5 repos           ⚠ We're missing Makefile detection
+  CMake: 3 repos              ⚠ We're not prioritizing CMake as expected
+```
+
+### What the Numbers Mean
+
+- **Exact Match**: GitHub's primary = Our primary (Best!)
+- **Partial Match**: We detected it, but prioritized differently
+- **Mismatch**: We missed GitHub's primary language
+
+**Target Goals:**
+
+- Exact match: >70%
+- Partial match: <20%
+- Mismatch: <15%
+
+---
+
+## Common Scenarios
+
+### Scenario 1: You Don't Have Repos Cloned
+
+**Fetch GitHub data first:**
+
+```bash
+python scripts/compare_github_languages.py \
+    --org onap \
+    --output github_baseline.json
+```
+
+This gives you a baseline of what GitHub sees. Review the JSON to understand:
+
+- What languages are most common
+- Which repos use which languages
+- Language byte counts and distributions
+
+### Scenario 2: You Have Some Repos Cloned
+
+**Run comparison on what you have:**
+
+```bash
+python scripts/compare_github_languages.py \
+    --org onap \
+    --repos-path ./repos \
+    --output partial_comparison.json
+```
+
+The script will:
+
+- Compare repos you have locally
+- Report on repos missing from local analysis
+- Still show full GitHub statistics
+
+### Scenario 3: Investigating Specific Mismatches
+
+**Focus on repos with mismatches:**
+
+1. Run full comparison:
+
+   ```bash
+   python scripts/compare_github_languages.py \
+       --org onap \
+       --repos-path ./repos \
+       --output full_comparison.json
+   ```
+
+2. Look at the "Sample Mismatches" section in output
+
+3. Clone specific repos with issues:
+
+   ```bash
+   cd repos
+   git clone https://github.com/onap/problematic-repo
+   ```
+
+4. Test local detection:
+
+   ```python
+   from pathlib import Path
+   from gerrit_reporting_tool.features.registry import FeatureRegistry
+   import logging
+
+   config = {"features": {"enabled": ["project_types"]}}
+   registry = FeatureRegistry(config, logging.getLogger())
+   result = registry._check_project_types(Path("./repos/problematic-repo"))
+   print(result)
+   ```
+
+5. Compare with GitHub's detection in JSON output
+
+---
+
+## Reading the JSON Output
+
+The output JSON has three main sections:
+
+### 1. `github_data`
+
+What GitHub detected for each repository:
+
+```json
+{
+  "policy-engine": {
+    "full_name": "onap/policy-engine",
+    "github_primary_language": "Java",
+    "languages": {
+      "Java": 2500000,
+      "Python": 50000,
+      "Shell": 10000
+    },
+    "calculated_primary": "Java",
+    "total_bytes": 2560000
+  }
+}
+```
+
+### 2. `local_data`
+
+What our detection found:
+
+```json
+{
+  "policy-engine": {
+    "detected_types": ["Java", "Python", "Dockerfile"],
+    "primary_type": "Java",
+    "details": [
+      {
+        "type": "Java",
+        "files": ["pom.xml", "Main.java"],
+        "confidence": 2
+      }
+    ]
+  }
+}
+```
+
+### 3. `comparison`
+
+Analysis of matches and mismatches:
+
+```json
+{
+  "statistics": {
+    "exact_matches": 142,
+    "partial_matches": 31,
+    "complete_mismatches": 25,
+    "exact_match_percentage": 71.7
+  },
+  "language_agreement": {
+    "Python": 89,
+    "Java": 42
+  },
+  "language_gaps": {
+    "Shell": 8,
+    "Makefile": 5
+  }
+}
+```
+
+---
+
+## Next Steps After Running Comparison
+
+### If Match Rate is Good (>70%)
+
+✓ Your detection is well-aligned!
+
+**Minor improvements:**
+
+- Review partial matches to improve prioritization
+- Add any missing languages from gaps report
+- Document known acceptable differences
+
+### If Match Rate is Medium (50-70%)
+
+⚠ Some alignment needed
+
+**Recommended actions:**
+
+1. Review "Language Detection Gaps" section
+2. Add missing language patterns
+3. Adjust confidence scoring
+4. Test on sample repos
+5. Re-run comparison
+
+### If Match Rate is Low (<50%)
+
+✗ Significant alignment needed
+
+**Required actions:**
+
+1. Audit detection logic in `registry.py`
+2. Compare file patterns with [GitHub Linguist](https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml)
+3. Review confidence scoring algorithm
+4. Consider byte-count weighting vs file-count
+5. Add comprehensive tests
+6. Re-run comparison after changes
+
+---
+
+## Tips for ONAP
+
+### Expected Languages in ONAP
+
+Based on ONAP's architecture, you should see:
+
+- **Java**: Policy, APPC, SDNC, SO components
+- **Python**: Testing, tooling, VVP, AI/ML components
+- **JavaScript/TypeScript**: Portal, SDC UI
+- **Go**: Some cloud-native services
+- **Dockerfile**: Common (containerized architecture)
+- **Shell**: Build scripts, deployment tooling
+- **YAML**: Configuration, Kubernetes manifests
+
+### ONAP-Specific Considerations
+
+- **Multi-language repos**: ONAP repos often use 2-3 languages
+
+2. **Infrastructure code**: Lots of Docker, Kubernetes, Helm
+
+- **Build systems**: Maven, Gradle are common
+
+4. **Test frameworks**: Robot Framework widely used
+
+### Realistic Goals for ONAP
+
+- Exact match: 65-75% (multi-language repos make this challenging)
+- Partial match: 15-25% (expected for mixed repos)
+- Mismatch: 10-15% (acceptable for edge cases)
+
+---
+
+## Troubleshooting
+
+### "No module named 'httpx'"
+
+```bash
+pip install httpx
+```
+
+### "No module named 'gerrit_reporting_tool'"
+
+```bash
+pip install -e .
+```
+
+### "401 Unauthorized"
+
+- Check your GitHub token is valid
+- Verify it has `public_repo` scope
+- Try: `curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user`
+
+### "Rate limit exceeded"
+
+- Wait 1 hour for reset
+- Check limits: `curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/rate_limit`
+
+### "No local data for repo X"
+
+- Ensure the repo exists in `--repos-path`
+- Check directory name matches GitHub repo name
+- Verify path is correct
+
+---
+
+## Full Documentation
+
+See [GITHUB_LANGUAGE_COMPARISON.md](../docs/GITHUB_LANGUAGE_COMPARISON.md) for:
+
+- Detailed usage examples
+- Advanced analysis techniques
+- Improving detection alignment
+- Understanding GitHub's detection
+- API reference
+
+---
+
+## Questions?
+
+1. Check the full documentation: `docs/GITHUB_LANGUAGE_COMPARISON.md`
+2. Review GitHub Linguist: <https://github.com/github-linguist/linguist>
+3. See project type detection: `docs/PROJECT_TYPE_DETECTION.md`

--- a/scripts/compare_github_languages.py
+++ b/scripts/compare_github_languages.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Compare GitHub Language Detection with Local Project Type Detection
+
+This script fetches language/project type data from GitHub for all repositories
+in an organization and compares it with our local detection results to identify
+gaps and alignment opportunities.
+
+Usage:
+    python scripts/compare_github_languages.py --org onap --github-token $GITHUB_TOKEN
+    python scripts/compare_github_languages.py --org onap --github-token $GITHUB_TOKEN --repos-path ./repos
+    python scripts/compare_github_languages.py --org onap --github-token $GITHUB_TOKEN --output comparison.json
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+try:
+    import httpx
+except ImportError:
+    print("Error: httpx is required. Install with: pip install httpx")
+    sys.exit(1)
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from gerrit_reporting_tool.features.registry import FeatureRegistry
+
+
+class GitHubLanguageAnalyzer:
+    """Fetch and analyze GitHub language detection for repositories."""
+
+    def __init__(self, token: str, timeout: float = 30.0):
+        """Initialize GitHub API client."""
+        self.token = token
+        self.base_url = "https://api.github.com"
+        self.client = httpx.Client(
+            base_url=self.base_url,
+            timeout=httpx.Timeout(timeout, connect=10.0),
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "gerrit-reporting-tool/compare-languages",
+            },
+        )
+        self.logger = logging.getLogger(__name__)
+
+    def close(self):
+        """Close the httpx client."""
+        self.client.close()
+
+    def get_organization_repos(self, org: str) -> list[dict[str, Any]]:
+        """
+        Fetch all repositories for an organization.
+
+        Args:
+            org: GitHub organization name
+
+        Returns:
+            List of repository information dicts
+        """
+        repos = []
+        page = 1
+        per_page = 100
+
+        self.logger.info(f"Fetching repositories for organization: {org}")
+
+        while True:
+            try:
+                response = self.client.get(
+                    f"/orgs/{org}/repos",
+                    params={"page": page, "per_page": per_page, "type": "all"},
+                )
+                response.raise_for_status()
+                page_repos = response.json()
+
+                if not page_repos:
+                    break
+
+                repos.extend(page_repos)
+                self.logger.info(f"Fetched {len(repos)} repositories so far...")
+                page += 1
+
+            except httpx.HTTPStatusError as e:
+                self.logger.error(f"HTTP error fetching repos: {e}")
+                break
+            except Exception as e:
+                self.logger.error(f"Error fetching repos: {e}")
+                break
+
+        self.logger.info(f"Total repositories found: {len(repos)}")
+        return repos
+
+    def get_repository_languages(self, owner: str, repo: str) -> dict[str, int]:
+        """
+        Fetch language statistics for a repository.
+
+        Args:
+            owner: Repository owner/organization
+            repo: Repository name
+
+        Returns:
+            Dict mapping language names to byte counts
+        """
+        try:
+            response = self.client.get(f"/repos/{owner}/{repo}/languages")
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            self.logger.warning(f"HTTP error fetching languages for {owner}/{repo}: {e}")
+            return {}
+        except Exception as e:
+            self.logger.warning(f"Error fetching languages for {owner}/{repo}: {e}")
+            return {}
+
+    def analyze_organization(self, org: str) -> dict[str, dict[str, Any]]:
+        """
+        Analyze all repositories in an organization.
+
+        Args:
+            org: GitHub organization name
+
+        Returns:
+            Dict mapping repo names to their language data
+        """
+        repos = self.get_organization_repos(org)
+        results = {}
+
+        for repo in repos:
+            repo_name = repo["name"]
+            self.logger.debug(f"Fetching languages for {repo_name}")
+
+            languages = self.get_repository_languages(org, repo_name)
+
+            # Calculate primary language (most bytes)
+            primary_language = None
+            if languages:
+                primary_language = max(languages.items(), key=lambda x: x[1])[0]
+
+            results[repo_name] = {
+                "full_name": repo["full_name"],
+                "html_url": repo["html_url"],
+                "github_primary_language": repo.get("language"),  # GitHub's reported primary
+                "languages": languages,
+                "calculated_primary": primary_language,
+                "total_bytes": sum(languages.values()),
+                "archived": repo.get("archived", False),
+                "fork": repo.get("fork", False),
+            }
+
+        return results
+
+
+class LocalProjectTypeAnalyzer:
+    """Analyze project types using local detection."""
+
+    def __init__(self):
+        """Initialize local analyzer."""
+        self.logger = logging.getLogger(__name__)
+        config = {"features": {"enabled": ["project_types"]}}
+        self.registry = FeatureRegistry(config, self.logger)
+
+    def analyze_repository(self, repo_path: Path) -> dict[str, Any]:
+        """
+        Analyze a local repository.
+
+        Args:
+            repo_path: Path to repository
+
+        Returns:
+            Dict with detected project types
+        """
+        if not repo_path.exists():
+            return {
+                "error": "Repository path not found",
+                "detected_types": [],
+                "primary_type": None,
+            }
+
+        try:
+            result = self.registry._check_project_types(repo_path)
+            return result
+        except Exception as e:
+            self.logger.error(f"Error analyzing {repo_path}: {e}")
+            return {
+                "error": str(e),
+                "detected_types": [],
+                "primary_type": None,
+            }
+
+    def find_repository_path(self, base_path: Path, github_repo_name: str) -> Path | None:
+        """
+        Find repository path supporting both flat and Gerrit-style structures.
+
+        GitHub repo names like "aai-aai-common" map to Gerrit structure like:
+        - /base/aai/aai-common  (Gerrit style: project/subproject)
+        - /base/aai-aai-common  (flat style)
+
+        Args:
+            base_path: Base directory containing repositories
+            github_repo_name: GitHub repository name (e.g., "aai-aai-common")
+
+        Returns:
+            Path to repository if found, None otherwise
+        """
+        # Try flat structure first
+        flat_path = base_path / github_repo_name
+        if flat_path.exists() and flat_path.is_dir():
+            return flat_path
+
+        # Try Gerrit-style structure (project/subproject)
+        # GitHub name format: {project}-{subproject} or variations
+        parts = github_repo_name.split("-", 1)
+        if len(parts) == 2:
+            project, subproject = parts
+            gerrit_path = base_path / project / subproject
+            if gerrit_path.exists() and gerrit_path.is_dir():
+                return gerrit_path
+
+        # For repos with multiple hyphens, try different splits
+        # e.g., "aai-aai-common" -> try "aai/aai-common"
+        parts = github_repo_name.split("-")
+        if len(parts) > 2:
+            for i in range(1, len(parts)):
+                project = "-".join(parts[:i])
+                subproject = "-".join(parts[i:])
+                gerrit_path = base_path / project / subproject
+                if gerrit_path.exists() and gerrit_path.is_dir():
+                    return gerrit_path
+
+        return None
+
+    def analyze_repositories(
+        self, repos_path: Path, repo_names: list[str]
+    ) -> dict[str, dict[str, Any]]:
+        """
+        Analyze multiple local repositories.
+
+        Args:
+            repos_path: Base path containing repositories
+            repo_names: List of repository names to analyze
+
+        Returns:
+            Dict mapping repo names to detection results (only for repos found locally)
+        """
+        results = {}
+
+        for repo_name in repo_names:
+            # Try to find repo in Gerrit-style or flat structure
+            repo_path = self.find_repository_path(repos_path, repo_name)
+
+            if repo_path:
+                self.logger.debug(f"Analyzing local repository: {repo_name} at {repo_path}")
+                results[repo_name] = self.analyze_repository(repo_path)
+            else:
+                self.logger.debug(f"Repository not found locally, skipping: {repo_name}")
+                # Don't add to results - we only want repos that exist locally
+
+        return results
+
+
+class LanguageComparisonAnalyzer:
+    """Compare GitHub and local language detection."""
+
+    def __init__(self):
+        """Initialize comparison analyzer."""
+        self.logger = logging.getLogger(__name__)
+
+    @staticmethod
+    def normalize_language_name(name: str) -> str:
+        """
+        Normalize language names for comparison.
+
+        Args:
+            name: Language or project type name
+
+        Returns:
+            Normalized name
+        """
+        # First, handle our combined types (Java/Maven, Java/Gradle) -> Java
+        if name and "/" in name and name.startswith("Java/"):
+            return "Java"
+
+        # Mapping from GitHub names to our names
+        name_mapping = {
+            "Dockerfile": "Dockerfile",
+            "JavaScript": "JavaScript",
+            "TypeScript": "TypeScript",
+            "Python": "Python",
+            "Java": "Java",
+            "C++": "C++",
+            "C": "C",
+            "Go": "Go",
+            "Rust": "Rust",
+            "Ruby": "Ruby",
+            "PHP": "PHP",
+            "Shell": "Shell",
+            "HTML": "HTML",
+            "CSS": "CSS",
+            "SCSS": "SCSS",
+            "Groovy": "Groovy",
+            "Kotlin": "Kotlin",
+            "Scala": "Scala",
+            "Swift": "Swift",
+            "Clojure": "Clojure",
+            "Erlang": "Erlang",
+            "Lua": "Lua",
+            "D": "D",
+            "HCL": "HCL",
+            "Smarty": "Smarty",
+            "EJS": "EJS",
+            "RobotFramework": "Robot Framework",
+            "Robot Framework": "Robot Framework",
+            ".NET": ".NET",
+            "C#": ".NET",
+            "CMake": "C++",
+            "Makefile": "C",
+            "Maven": "Java",
+            "Gradle": "Java",
+        }
+
+        return name_mapping.get(name, name)
+
+    def compare_repositories(
+        self,
+        github_data: dict[str, dict[str, Any]],
+        local_data: dict[str, dict[str, Any]],
+    ) -> dict[str, Any]:
+        """
+        Compare GitHub and local detection results.
+
+        Args:
+            github_data: GitHub language data
+            local_data: Local detection data
+
+        Returns:
+            Comparison analysis
+        """
+        comparison = {
+            "total_repos": len(github_data),
+            "matches": [],
+            "mismatches": [],
+            "github_only": [],
+            "local_only": [],
+            "statistics": {
+                "exact_matches": 0,
+                "partial_matches": 0,
+                "complete_mismatches": 0,
+                "skipped_not_local": 0,
+                "analyzed_locally": 0,
+            },
+            "language_gaps": defaultdict(int),
+            "language_agreement": defaultdict(int),
+        }
+
+        for repo_name, gh_data in github_data.items():
+            # Skip archived and forked repos
+            if gh_data.get("archived") or gh_data.get("fork"):
+                continue
+
+            local_result = local_data.get(repo_name)
+
+            # Skip repos not found locally (archived/removed repos)
+            if not local_result:
+                comparison["statistics"]["skipped_not_local"] += 1
+                self.logger.debug(f"Skipping {repo_name} - not found locally")
+                continue
+
+            # Count repos analyzed locally (excluding archived/forked)
+            comparison["statistics"]["analyzed_locally"] += 1
+
+            # Get GitHub's primary language
+            gh_primary = gh_data.get("github_primary_language")
+            gh_languages = set(gh_data.get("languages", {}).keys())
+
+            # Get our detected types
+            local_primary = local_result.get("primary_type")
+            local_types = set(local_result.get("detected_types", []))
+
+            # Normalize names for comparison
+            gh_primary_norm = self.normalize_language_name(gh_primary) if gh_primary else None
+            local_primary_norm = (
+                self.normalize_language_name(local_primary) if local_primary else None
+            )
+            local_types_norm = {self.normalize_language_name(t) for t in local_types}
+
+            # Compare
+            if gh_primary_norm and gh_primary_norm == local_primary_norm:
+                comparison["statistics"]["exact_matches"] += 1
+                comparison["language_agreement"][gh_primary_norm] += 1
+                comparison["matches"].append(
+                    {
+                        "repo": repo_name,
+                        "language": gh_primary_norm,
+                        "github_languages": list(gh_languages),
+                        "local_types": list(local_types),
+                    }
+                )
+            elif gh_primary_norm and gh_primary_norm in local_types_norm:
+                comparison["statistics"]["partial_matches"] += 1
+                comparison["language_agreement"][gh_primary_norm] += 1
+                comparison["matches"].append(
+                    {
+                        "repo": repo_name,
+                        "language": gh_primary_norm,
+                        "match_type": "partial",
+                        "github_primary": gh_primary,
+                        "local_primary": local_primary,
+                        "github_languages": list(gh_languages),
+                        "local_types": list(local_types),
+                    }
+                )
+            else:
+                comparison["statistics"]["complete_mismatches"] += 1
+                comparison["mismatches"].append(
+                    {
+                        "repo": repo_name,
+                        "github_primary": gh_primary,
+                        "local_primary": local_primary,
+                        "github_languages": list(gh_languages),
+                        "local_types": list(local_types),
+                    }
+                )
+
+                # Track gaps
+                if gh_primary:
+                    comparison["language_gaps"][gh_primary] += 1
+
+        # Calculate percentages
+        analyzed = comparison["statistics"]["analyzed_locally"]
+
+        # Add analyzed_locally to top level for easy access
+        comparison["analyzed_locally"] = comparison["statistics"]["analyzed_locally"]
+
+        if analyzed > 0:
+            comparison["statistics"]["exact_match_percentage"] = (
+                comparison["statistics"]["exact_matches"] / analyzed * 100
+            )
+            comparison["statistics"]["partial_match_percentage"] = (
+                comparison["statistics"]["partial_matches"] / analyzed * 100
+            )
+            comparison["statistics"]["mismatch_percentage"] = (
+                comparison["statistics"]["complete_mismatches"] / analyzed * 100
+            )
+
+        return comparison
+
+    def generate_report(self, comparison: dict[str, Any]) -> str:
+        """
+        Generate a human-readable comparison report.
+
+        Args:
+            comparison: Comparison analysis
+
+        Returns:
+            Formatted report text
+        """
+        report_lines = [
+            "=" * 80,
+            "GitHub vs Local Language Detection Comparison",
+            "=" * 80,
+            "",
+            "Summary:",
+            f"  Total GitHub repos: {comparison['total_repos']}",
+            f"  Skipped (not found locally): {comparison['statistics']['skipped_not_local']}",
+            f"  Analyzed locally: {comparison['statistics']['analyzed_locally']}",
+            "",
+            "Results for locally available repos:",
+            f"  Exact matches: {comparison['statistics']['exact_matches']}",
+            f"  Partial matches: {comparison['statistics']['partial_matches']}",
+            f"  Complete mismatches: {comparison['statistics']['complete_mismatches']}",
+            "",
+        ]
+
+        if comparison["statistics"]["analyzed_locally"] > 0:
+            report_lines.extend(
+                [
+                    "Match Percentages:",
+                    f"  Exact matches: {comparison['statistics'].get('exact_match_percentage', 0):.1f}%",
+                    f"  Partial matches: {comparison['statistics'].get('partial_match_percentage', 0):.1f}%",
+                    f"  Mismatches: {comparison['statistics'].get('mismatch_percentage', 0):.1f}%",
+                    "",
+                ]
+            )
+
+        # Language agreement
+        if comparison["language_agreement"]:
+            report_lines.extend(
+                [
+                    "Languages with Good Agreement:",
+                    "  (GitHub primary language matched our detection)",
+                ]
+            )
+            for lang, count in sorted(
+                comparison["language_agreement"].items(), key=lambda x: x[1], reverse=True
+            ):
+                report_lines.append(f"  {lang}: {count} repos")
+            report_lines.append("")
+
+        # Language gaps
+        if comparison["language_gaps"]:
+            report_lines.extend(
+                [
+                    "Language Detection Gaps:",
+                    "  (GitHub detected but we missed as primary)",
+                ]
+            )
+            for lang, count in sorted(
+                comparison["language_gaps"].items(), key=lambda x: x[1], reverse=True
+            ):
+                report_lines.append(f"  {lang}: {count} repos")
+            report_lines.append("")
+
+        # Sample mismatches
+        if comparison["mismatches"]:
+            report_lines.extend(
+                [
+                    "Sample Mismatches (first 10):",
+                ]
+            )
+            for mismatch in comparison["mismatches"][:10]:
+                report_lines.append(f"  Repository: {mismatch['repo']}")
+                report_lines.append(f"    GitHub primary: {mismatch['github_primary']}")
+                report_lines.append(f"    Our primary: {mismatch['local_primary']}")
+                report_lines.append(
+                    f"    GitHub languages: {', '.join(mismatch.get('github_languages', []))}"
+                )
+                report_lines.append(f"    Our types: {', '.join(mismatch.get('local_types', []))}")
+                report_lines.append("")
+
+        report_lines.append("=" * 80)
+        return "\n".join(report_lines)
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Compare GitHub language detection with local project type detection"
+    )
+    parser.add_argument(
+        "--org",
+        required=True,
+        help="GitHub organization name (e.g., onap)",
+    )
+    parser.add_argument(
+        "--github-token",
+        help="GitHub personal access token (or set GITHUB_TOKEN env var)",
+    )
+    parser.add_argument(
+        "--repos-path",
+        type=Path,
+        help="Path to directory containing cloned repositories",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output file for detailed JSON comparison (default: stdout)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level",
+    )
+
+    args = parser.parse_args()
+
+    # Setup logging
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    logger = logging.getLogger(__name__)
+
+    # Get GitHub token
+    github_token = args.github_token or os.environ.get("GITHUB_TOKEN")
+    if not github_token:
+        logger.error("GitHub token required. Use --github-token or set GITHUB_TOKEN env var")
+        return 1
+
+    try:
+        # Fetch GitHub data
+        logger.info(f"Fetching GitHub language data for organization: {args.org}")
+        gh_analyzer = GitHubLanguageAnalyzer(github_token)
+        github_data = gh_analyzer.analyze_organization(args.org)
+        gh_analyzer.close()
+
+        logger.info(f"Fetched data for {len(github_data)} repositories from GitHub")
+
+        # Analyze local repositories if path provided
+        local_data = {}
+        if args.repos_path:
+            logger.info(f"Analyzing local repositories in: {args.repos_path}")
+            local_analyzer = LocalProjectTypeAnalyzer()
+            repo_names = list(github_data)
+            local_data = local_analyzer.analyze_repositories(args.repos_path, repo_names)
+            logger.info(f"Analyzed {len(local_data)} local repositories")
+        else:
+            logger.warning("No --repos-path provided, skipping local analysis")
+
+        # Compare
+        logger.info("Comparing GitHub and local detection results")
+        comparator = LanguageComparisonAnalyzer()
+        comparison = comparator.compare_repositories(github_data, local_data)
+
+        # Generate report
+        report = comparator.generate_report(comparison)
+        print("\n" + report)
+
+        # Save detailed JSON if requested
+        if args.output:
+            output_data = {
+                "github_data": github_data,
+                "local_data": local_data,
+                "comparison": comparison,
+            }
+            with open(args.output, "w") as f:
+                json.dump(output_data, f, indent=2)
+            logger.info(f"Detailed comparison saved to: {args.output}")
+
+        return 0
+
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+        return 130
+    except Exception as e:
+        logger.error(f"Error: {e}", exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Have checked to ensure our project type detection is comparable to GitHub's. Only four repositories are mismatched; one was ci-management (we label JJB). The others were all repositories with mixed content, and not pure code. Since those are highly subjective, I consider our behaviour acceptable in quality.