### PR TITLE
Feat!: Make GitHub2Gerrit workflow/detection names configurable

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -95,6 +95,18 @@ features:
     - workflows
     - gitreview
 
+  # Per-feature configuration (optional)
+  # Customize feature detection behavior on a per-project basis
+
+  # G2G (GitHub2Gerrit) workflow detection
+  # Specify custom workflow filenames to check in .github/workflows/
+  # If not specified, defaults to: github2gerrit.yaml, call-github2gerrit.yaml
+  # g2g:
+  #   workflow_files:
+  #     - "github2gerrit.yaml"
+  #     - "call-github2gerrit.yaml"
+  #     # Add custom workflow names here for your project
+
 # =============================================================================
 # Workflow Classification
 # =============================================================================
@@ -314,4 +326,4 @@ extensions:
 # =============================================================================
 # Schema Version
 # =============================================================================
-schema_version: "1.0.0"
+schema_version: "1.1.0"

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -127,6 +127,27 @@ jjb_attribution:
   cache_dir: /tmp
 ```
 
+### G2G (GitHub2Gerrit) Custom Workflow Detection
+
+To customize which workflow files are checked for GitHub2Gerrit synchronization:
+
+```yaml
+features:
+  enabled:
+    - g2g
+
+  g2g:
+    workflow_files:
+      - "github2gerrit.yaml"
+      - "call-github2gerrit.yaml"
+      - "sync-to-gerrit.yaml"        # Custom workflow name
+      - "custom-gerrit-mirror.yaml"  # Another custom name
+```
+
+**Default Behavior**: If not specified, the tool checks for `github2gerrit.yaml` and `call-github2gerrit.yaml`.
+
+**Custom Configuration**: Projects can specify their own workflow filenames. If **any** of the listed workflows exist in `.github/workflows/`, the G2G feature is marked as present (✅) in the report.
+
 ## Validation
 
 All configuration files are validated against the schema. To check if a configuration is valid:

--- a/configuration/default.yaml
+++ b/configuration/default.yaml
@@ -90,6 +90,18 @@ features:
     - workflows
     - gitreview
 
+  # Per-feature configuration (optional)
+  # Customize feature detection behavior on a per-project basis
+
+  # G2G (GitHub2Gerrit) workflow detection
+  # Specify custom workflow filenames to check in .github/workflows/
+  # If not specified, defaults to: github2gerrit.yaml, call-github2gerrit.yaml
+  # g2g:
+  #   workflow_files:
+  #     - "github2gerrit.yaml"
+  #     - "call-github2gerrit.yaml"
+  #     # Add custom workflow names here for your project
+
 # =============================================================================
 # Workflow Classification
 # =============================================================================
@@ -309,4 +321,4 @@ extensions:
 # =============================================================================
 # Schema Version
 # =============================================================================
-schema_version: "1.0.0"
+schema_version: "1.1.0"

--- a/docs/FEATURE_DISCOVERY_GUIDE.md
+++ b/docs/FEATURE_DISCOVERY_GUIDE.md
@@ -446,6 +446,68 @@ A: Edit `src/cli/features.py` and add to `AVAILABLE_FEATURES` registry.
 
 ---
 
+## Customizing Feature Detection
+
+### Per-Project Feature Configuration
+
+Some features support per-project customization through configuration files. This allows projects with non-standard conventions to be properly detected.
+
+#### G2G (GitHub2Gerrit) Workflow Customization
+
+The G2G feature detects GitHub to Gerrit workflow synchronization by checking for specific workflow files in `.github/workflows/`. By default, it looks for:
+
+- `github2gerrit.yaml`
+- `call-github2gerrit.yaml`
+
+**Customizing Workflow Filenames:**
+
+If your project uses custom workflow names, you can configure them in your project-specific configuration file:
+
+```yaml
+# configuration/myproject.yaml
+project: My Project
+
+features:
+  enabled:
+    - g2g
+
+  g2g:
+    workflow_files:
+      - "github2gerrit.yaml"           # Standard
+      - "call-github2gerrit.yaml"      # Standard
+      - "sync-to-gerrit.yaml"          # Custom
+      - "custom-gerrit-mirror.yaml"    # Custom
+```
+
+**Detection Logic:**
+
+- If **any** of the configured workflow files exist in `.github/workflows/`, the G2G feature is marked as present (✅)
+- If **none** of the workflow files exist, it's marked as absent (❌)
+- Multiple workflow files can be specified
+- Each project can have its own list of workflow filenames
+
+**Example Use Case:**
+
+A project that uses a non-standard workflow naming convention:
+
+```yaml
+features:
+  g2g:
+    workflow_files:
+      - "gerrit-sync.yaml"
+      - "mirror-to-gerrit.yaml"
+```
+
+**Backward Compatibility:**
+
+- If `features.g2g.workflow_files` is not specified, the default filenames are used
+- Existing configurations continue to work without changes
+- No configuration changes are required for projects using standard workflow names
+
+**Schema Version:** This feature requires schema version 1.1.0 or later.
+
+---
+
 ## Advanced Usage
 
 ### Custom Feature Registry

--- a/src/config/schema.json
+++ b/src/config/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/lfit/releng-reports/config-schema/v1.0.0",
+  "$id": "https://github.com/lfit/releng-reports/config-schema/v1.1.0",
   "title": "Repository Reporting System Configuration Schema",
   "description": "Schema for validating repository analysis configuration files",
   "type": "object",
@@ -134,6 +134,22 @@
             ]
           },
           "uniqueItems": true
+        },
+        "g2g": {
+          "type": "object",
+          "properties": {
+            "workflow_files": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "uniqueItems": true,
+              "minItems": 1,
+              "description": "List of workflow filenames to check for G2G (GitHub2Gerrit) detection"
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -149,8 +149,8 @@ class ValidationResult:
 class ConfigValidator:
     """Validates configuration against schema and semantic rules."""
 
-    CURRENT_SCHEMA_VERSION = "1.0.0"
-    COMPATIBLE_SCHEMA_VERSIONS = ["1.0.0"]
+    CURRENT_SCHEMA_VERSION = "1.1.0"
+    COMPATIBLE_SCHEMA_VERSIONS = ["1.0.0", "1.1.0"]
 
     def __init__(self, schema_path: Optional[Path] = None):
         """Initialize validator with optional custom schema.
@@ -269,7 +269,7 @@ class ConfigValidator:
         if error.validator == "required":
             missing = error.message.split("'")[1]
             if missing == "schema_version":
-                return "Add 'schema_version: \"1.0.0\"' to your configuration"
+                return "Add 'schema_version: \"1.1.0\"' to your configuration"
             elif missing == "project":
                 return "Add 'project: your-project-name' to your configuration"
         elif error.validator == "additionalProperties":

--- a/src/domain/time_window.py
+++ b/src/domain/time_window.py
@@ -204,10 +204,10 @@ class TimeWindowStats:
             contributors=data.get("contributors", 0),
         )
 
-    def __add__(self, other: "TimeWindowStats") -> "TimeWindowStats":
+    def __add__(self, other: object) -> "TimeWindowStats":
         """Add two TimeWindowStats together for aggregation."""
         if not isinstance(other, TimeWindowStats):
-            return NotImplemented  # type: ignore[unreachable]
+            return NotImplemented
 
         return TimeWindowStats(
             commits=self.commits + other.commits,

--- a/src/gerrit_reporting_tool/features/registry.py
+++ b/src/gerrit_reporting_tool/features/registry.py
@@ -217,6 +217,18 @@ class FeatureRegistry:
         """
         Check for specific GitHub to Gerrit workflow files.
 
+        Checks for workflow files in .github/workflows/ directory. The list of
+        workflow filenames can be customized per-project via configuration:
+
+        features:
+          g2g:
+            workflow_files:
+              - "github2gerrit.yaml"
+              - "call-github2gerrit.yaml"
+              - "custom-workflow.yaml"
+
+        If not specified in config, defaults to: github2gerrit.yaml, call-github2gerrit.yaml
+
         Args:
             repo_path: Path to the repository
 
@@ -224,7 +236,16 @@ class FeatureRegistry:
             Dict with keys: present (bool), file_paths (list), file_path (str or None)
         """
         workflows_dir = repo_path / ".github" / "workflows"
-        g2g_files = ["github2gerrit.yaml", "call-github2gerrit.yaml"]
+
+        # Get workflow files from config, with backward-compatible defaults
+        default_g2g_files = ["github2gerrit.yaml", "call-github2gerrit.yaml"]
+        features_config = self.config.get("features", {})
+        g2g_config = features_config.get("g2g", {})
+        g2g_files = g2g_config.get("workflow_files", default_g2g_files)
+
+        # Ensure g2g_files is a list
+        if isinstance(g2g_files, str):
+            g2g_files = [g2g_files]
 
         found_files = []
         for filename in g2g_files:

--- a/src/gerrit_reporting_tool/main.py
+++ b/src/gerrit_reporting_tool/main.py
@@ -49,7 +49,7 @@ try:
 except ImportError:
     __version__ = "0.0.0"  # Fallback if not installed
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
 DEFAULT_CONFIG_DIR = "configuration"
 DEFAULT_OUTPUT_DIR = "reports"
 

--- a/tests/unit/test_g2g_feature.py
+++ b/tests/unit/test_g2g_feature.py
@@ -1,0 +1,366 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Unit tests for G2G (GitHub2Gerrit) feature detection with configurable workflow files.
+
+Tests verify:
+- Default workflow file detection (github2gerrit.yaml, call-github2gerrit.yaml)
+- Custom workflow file configuration
+- Single custom workflow file
+- Multiple custom workflow files
+- Backward compatibility when no configuration is provided
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gerrit_reporting_tool.features.registry import FeatureRegistry
+
+
+@pytest.fixture
+def logger():
+    """Create a logger for testing."""
+    return logging.getLogger(__name__)
+
+
+@pytest.fixture
+def temp_repo(tmp_path: Path) -> Path:
+    """Create a temporary repository structure."""
+    repo_path = tmp_path / "test-repo"
+    repo_path.mkdir()
+    workflows_dir = repo_path / ".github" / "workflows"
+    workflows_dir.mkdir(parents=True)
+    return repo_path
+
+
+def create_workflow_file(repo_path: Path, filename: str) -> None:
+    """Create a workflow file in the repository."""
+    workflow_path = repo_path / ".github" / "workflows" / filename
+    workflow_path.write_text("# Test workflow\n")
+
+
+class TestG2GFeatureDefaults:
+    """Test G2G feature detection with default configuration."""
+
+    def test_no_workflow_files_found(self, temp_repo: Path, logger: logging.Logger):
+        """Test that G2G is not detected when no workflow files exist."""
+        config: dict[str, Any] = {"features": {"enabled": ["g2g"]}}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is False
+        assert result["file_paths"] == []
+        assert result["file_path"] is None
+
+    def test_github2gerrit_yaml_detected(self, temp_repo: Path, logger: logging.Logger):
+        """Test that github2gerrit.yaml is detected by default."""
+        create_workflow_file(temp_repo, "github2gerrit.yaml")
+
+        config: dict[str, Any] = {"features": {"enabled": ["g2g"]}}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert ".github/workflows/github2gerrit.yaml" in result["file_paths"]
+        assert result["file_path"] == ".github/workflows/github2gerrit.yaml"
+
+    def test_call_github2gerrit_yaml_detected(self, temp_repo: Path, logger: logging.Logger):
+        """Test that call-github2gerrit.yaml is detected by default."""
+        create_workflow_file(temp_repo, "call-github2gerrit.yaml")
+
+        config: dict[str, Any] = {"features": {"enabled": ["g2g"]}}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert ".github/workflows/call-github2gerrit.yaml" in result["file_paths"]
+        assert result["file_path"] == ".github/workflows/call-github2gerrit.yaml"
+
+    def test_both_default_workflows_detected(self, temp_repo: Path, logger: logging.Logger):
+        """Test that both default workflow files are detected when present."""
+        create_workflow_file(temp_repo, "github2gerrit.yaml")
+        create_workflow_file(temp_repo, "call-github2gerrit.yaml")
+
+        config: dict[str, Any] = {"features": {"enabled": ["g2g"]}}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert len(result["file_paths"]) == 2
+        assert ".github/workflows/github2gerrit.yaml" in result["file_paths"]
+        assert ".github/workflows/call-github2gerrit.yaml" in result["file_paths"]
+
+    def test_non_default_workflow_not_detected(self, temp_repo: Path, logger: logging.Logger):
+        """Test that non-default workflow files are not detected without config."""
+        create_workflow_file(temp_repo, "custom-gerrit-sync.yaml")
+
+        config: dict[str, Any] = {"features": {"enabled": ["g2g"]}}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is False
+        assert result["file_paths"] == []
+
+
+class TestG2GFeatureCustomConfiguration:
+    """Test G2G feature detection with custom workflow file configuration."""
+
+    def test_single_custom_workflow_detected(self, temp_repo: Path, logger: logging.Logger):
+        """Test detection with a single custom workflow filename."""
+        create_workflow_file(temp_repo, "sync-to-gerrit.yaml")
+
+        config: dict[str, Any] = {
+            "features": {"enabled": ["g2g"], "g2g": {"workflow_files": ["sync-to-gerrit.yaml"]}}
+        }
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert ".github/workflows/sync-to-gerrit.yaml" in result["file_paths"]
+
+    def test_multiple_custom_workflows_detected(self, temp_repo: Path, logger: logging.Logger):
+        """Test detection with multiple custom workflow filenames."""
+        create_workflow_file(temp_repo, "gerrit-sync.yaml")
+        create_workflow_file(temp_repo, "mirror-to-gerrit.yaml")
+
+        config: dict[str, Any] = {
+            "features": {
+                "enabled": ["g2g"],
+                "g2g": {
+                    "workflow_files": [
+                        "gerrit-sync.yaml",
+                        "mirror-to-gerrit.yaml",
+                        "another-workflow.yaml",
+                    ]
+                },
+            }
+        }
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert len(result["file_paths"]) == 2
+        assert ".github/workflows/gerrit-sync.yaml" in result["file_paths"]
+        assert ".github/workflows/mirror-to-gerrit.yaml" in result["file_paths"]
+
+    def test_custom_config_overrides_defaults(self, temp_repo: Path, logger: logging.Logger):
+        """Test that custom configuration completely overrides defaults."""
+        # Create default workflow file
+        create_workflow_file(temp_repo, "github2gerrit.yaml")
+
+        # Configure only a custom workflow
+        config: dict[str, Any] = {
+            "features": {"enabled": ["g2g"], "g2g": {"workflow_files": ["custom-workflow.yaml"]}}
+        }
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        # Should not detect the default file since we overrode the config
+        assert result["present"] is False
+        assert result["file_paths"] == []
+
+    def test_mix_of_default_and_custom_workflows(self, temp_repo: Path, logger: logging.Logger):
+        """Test configuration with both default and custom workflow names."""
+        create_workflow_file(temp_repo, "github2gerrit.yaml")
+        create_workflow_file(temp_repo, "custom-sync.yaml")
+
+        config: dict[str, Any] = {
+            "features": {
+                "enabled": ["g2g"],
+                "g2g": {
+                    "workflow_files": [
+                        "github2gerrit.yaml",
+                        "call-github2gerrit.yaml",
+                        "custom-sync.yaml",
+                    ]
+                },
+            }
+        }
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert len(result["file_paths"]) == 2
+        assert ".github/workflows/github2gerrit.yaml" in result["file_paths"]
+        assert ".github/workflows/custom-sync.yaml" in result["file_paths"]
+
+    def test_any_match_is_sufficient(self, temp_repo: Path, logger: logging.Logger):
+        """Test that finding ANY configured workflow file marks G2G as present."""
+        # Create only one of multiple configured workflows
+        create_workflow_file(temp_repo, "workflow-b.yaml")
+
+        config: dict[str, Any] = {
+            "features": {
+                "enabled": ["g2g"],
+                "g2g": {
+                    "workflow_files": ["workflow-a.yaml", "workflow-b.yaml", "workflow-c.yaml"]
+                },
+            }
+        }
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert len(result["file_paths"]) == 1
+        assert ".github/workflows/workflow-b.yaml" in result["file_paths"]
+
+    def test_string_workflow_file_converted_to_list(self, temp_repo: Path, logger: logging.Logger):
+        """Test that a single string workflow_files value is converted to a list."""
+        create_workflow_file(temp_repo, "single-workflow.yaml")
+
+        config: dict[str, Any] = {
+            "features": {"enabled": ["g2g"], "g2g": {"workflow_files": "single-workflow.yaml"}}
+        }
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert ".github/workflows/single-workflow.yaml" in result["file_paths"]
+
+
+class TestG2GFeatureBackwardCompatibility:
+    """Test backward compatibility of G2G feature detection."""
+
+    def test_empty_config_uses_defaults(self, temp_repo: Path, logger: logging.Logger):
+        """Test that empty config falls back to defaults."""
+        create_workflow_file(temp_repo, "github2gerrit.yaml")
+
+        config: dict[str, Any] = {}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert ".github/workflows/github2gerrit.yaml" in result["file_paths"]
+
+    def test_no_features_section_uses_defaults(self, temp_repo: Path, logger: logging.Logger):
+        """Test that missing features section uses defaults."""
+        create_workflow_file(temp_repo, "call-github2gerrit.yaml")
+
+        config: dict[str, Any] = {"project": "test-project"}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert ".github/workflows/call-github2gerrit.yaml" in result["file_paths"]
+
+    def test_empty_g2g_config_uses_defaults(self, temp_repo: Path, logger: logging.Logger):
+        """Test that empty g2g config section uses defaults."""
+        create_workflow_file(temp_repo, "github2gerrit.yaml")
+
+        config: dict[str, Any] = {"features": {"enabled": ["g2g"], "g2g": {}}}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert ".github/workflows/github2gerrit.yaml" in result["file_paths"]
+
+    def test_result_structure_unchanged(self, temp_repo: Path, logger: logging.Logger):
+        """Test that the result structure remains consistent."""
+        create_workflow_file(temp_repo, "github2gerrit.yaml")
+
+        config: dict[str, Any] = {"features": {"enabled": ["g2g"]}}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        # Verify expected keys exist
+        assert "present" in result
+        assert "file_paths" in result
+        assert "file_path" in result
+
+        # Verify types
+        assert isinstance(result["present"], bool)
+        assert isinstance(result["file_paths"], list)
+        assert isinstance(result["file_path"], str) or result["file_path"] is None
+
+
+class TestG2GFeatureEdgeCases:
+    """Test edge cases for G2G feature detection."""
+
+    def test_workflows_directory_missing(self, temp_repo: Path, logger: logging.Logger):
+        """Test that missing .github/workflows directory is handled gracefully."""
+        # Remove the workflows directory
+        import shutil
+
+        workflows_dir = temp_repo / ".github" / "workflows"
+        if workflows_dir.exists():
+            shutil.rmtree(workflows_dir)
+
+        config: dict[str, Any] = {"features": {"enabled": ["g2g"]}}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is False
+        assert result["file_paths"] == []
+
+    def test_empty_workflow_files_list(self, temp_repo: Path, logger: logging.Logger):
+        """Test behavior with empty workflow_files list."""
+        create_workflow_file(temp_repo, "github2gerrit.yaml")
+
+        config: dict[str, Any] = {"features": {"enabled": ["g2g"], "g2g": {"workflow_files": []}}}
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        # Empty list means nothing to check, so nothing found
+        assert result["present"] is False
+        assert result["file_paths"] == []
+
+    def test_case_sensitive_matching(self, temp_repo: Path, logger: logging.Logger):
+        """Test that workflow filename matching follows filesystem case sensitivity."""
+        import platform
+
+        create_workflow_file(temp_repo, "GitHub2Gerrit.yaml")
+
+        config: dict[str, Any] = {
+            "features": {"enabled": ["g2g"], "g2g": {"workflow_files": ["github2gerrit.yaml"]}}
+        }
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        # On case-insensitive filesystems (macOS, Windows), it will match
+        # On case-sensitive filesystems (Linux), it will not match
+        # We just verify the detection works based on filesystem behavior
+        if platform.system() in ["Darwin", "Windows"]:
+            # Case-insensitive filesystem
+            assert result["present"] is True
+        else:
+            # Case-sensitive filesystem (Linux)
+            assert result["present"] is False
+
+    def test_whitespace_in_filename(self, temp_repo: Path, logger: logging.Logger):
+        """Test handling of workflow filenames with whitespace."""
+        create_workflow_file(temp_repo, "workflow with spaces.yaml")
+
+        config: dict[str, Any] = {
+            "features": {
+                "enabled": ["g2g"],
+                "g2g": {"workflow_files": ["workflow with spaces.yaml"]},
+            }
+        }
+        registry = FeatureRegistry(config, logger)
+
+        result = registry._check_g2g(temp_repo)
+
+        assert result["present"] is True
+        assert ".github/workflows/workflow with spaces.yaml" in result["file_paths"]


### PR DESCRIPTION
Still defaults to:
- github2gerrit.yaml
- call-github2gerrit.yaml

However, these file/workflow names can now be configured on a per-project basis.