### PR TITLE
Fix(ci): restrict top-level token perms

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -29,8 +29,7 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
-permissions:
-  actions: write  # Required for cache deletion when clear_cache is true
+permissions: {}
 
 jobs:
   python-build:


### PR DESCRIPTION
## Summary

Fix the OpenSSF Scorecard **Token-Permissions** alert by removing
the overly broad top-level `actions: write` permission from
`build-test.yaml`.

## Problem

The `build-test.yaml` workflow had `actions: write` set at the
**top level**, which violates the Scorecard principle of least
privilege (alert **#38**). This caused the Token-Permissions check
to score **0/10**, which in turn caused all 9 Token-Permissions
alerts to report `score is 0`.

## Fix

Change top-level `permissions` from `actions: write` to `{}`
(none). The `actions: write` permission is already correctly
declared at the `python-build` job level (the only job that needs
it for cache deletion), making the top-level declaration redundant.

## Impact on All 9 Token-Permissions Alerts

| Alert | File | Issue | Status |
|-------|------|-------|--------|
| **#38** | `build-test.yaml:33` | topLevel `actions: write` | ✅ **Fixed** |
| **#35** | `build-test.yaml:45` | jobLevel `actions: write` | ⚠️ Warning (necessary for cache deletion) |
| **#47** | `release-drafter.yaml:24` | jobLevel `contents: write` | ⚠️ Warning (necessary to create releases) |
| **#37** | `reporting-production.yaml:662` | jobLevel `contents: write` | ⚠️ Warning (necessary for GitHub Pages) |
| **#36** | `reporting-previews.yaml:425` | jobLevel `contents: write` | ⚠️ Warning (necessary for preview publish) |
| **#5** | `openssf-scorecard.yaml:36` | jobLevel `security-events: write` | ⚠️ Warning (necessary for SARIF upload) |
| **#4** | `codeql.yml:31` | jobLevel `security-events: write` | ⚠️ Warning (necessary for SARIF upload) |
| **#3** | `build-test-release.yaml:371` | jobLevel `contents: write` | ⚠️ Warning (necessary to attach release artefacts) |
| **#2** | `build-test-release.yaml:307` | jobLevel `contents: write` | ⚠️ Warning (necessary to promote draft release) |

The remaining 8 alerts are **job-level warnings** about legitimate
write permissions that are correctly scoped and necessary for their
respective jobs. Per the [Scorecard docs][1], these should not
reduce the score:

> *\"points are not reduced if the job utilizes a recognized
> packaging action or command\"* (for `contents: write`)

> *\"points are not reduced if the job utilizes a recognized action
> for uploading SARIF results\"* (for `security-events: write`)

All other workflow files already have `permissions: {}` at the top
level, which is the correct pattern.

[1]: https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions