### PR TITLE
Fix(coverage): Repair coverage measurement under python-test-action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,14 +199,25 @@ filterwarnings = [
 
 # Coverage configuration
 [tool.coverage.run]
-source = ["src"]
+source = [
+    "lf_releng_project_reporting",
+    "api",
+    "cli",
+    "concurrency",
+    "config",
+    "domain",
+    "jjb_attribution",
+    "observability",
+    "performance",
+    "rendering",
+    "util",
+]
 branch = true
 parallel = true
 omit = [
     "*/tests/*",
     "*/test_*.py",
     "*/__pycache__/*",
-    "*/site-packages/*",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary

Two related bugs in `[tool.coverage.run]` cause `No data was collected` / 0% coverage when this project is tested via `lfreleng-actions/python-test-action` v1.1.x (which installs the package **non-editably** into `.venv` by default):

1. **`source = ["src"]`** is a filesystem path, not a package name. The project ships multiple top-level packages under `src/`; coverage.py treats path-like `source` entries as path filters, and the installed packages live at `.venv/lib/pythonX.Y/site-packages/<pkg>/`, which the filter never matched. Listing each package by its import name fixes this.

2. **`omit` included `*/site-packages/*`**. That glob explicitly excludes the very directory where the non-editable install lives — so even after fixing `source`, the `omit` list would have excluded every measured file. This was the most aggressive instance of the pattern across the org.

This is the same class of bug that broke `markdown-table-fixer` on PR [#129](https://github.com/lfreleng-actions/markdown-table-fixer/pull/129). The workflow here is currently pinned to `python-test-action@v1.0.2`, so the regression is latent — it will surface as soon as Dependabot bumps the action to v1.1.x.

## Fix

```diff
 [tool.coverage.run]
-source = ["src"]
+source = [
+    "lf_releng_project_reporting",
+    "api",
+    "cli",
+    "concurrency",
+    "config",
+    "domain",
+    "jjb_attribution",
+    "observability",
+    "performance",
+    "rendering",
+    "util",
+]
 branch = true
 parallel = true
 omit = [
     "*/tests/*",
     "*/test_*.py",
     "*/__pycache__/*",
-    "*/site-packages/*",
 ]
```

The package list mirrors `[tool.hatch.build.targets.wheel].packages` so any future package additions there should be reflected here as well.