### PR TITLE
Fix: Improve workflow resilience and date handling in re-runs

### DIFF
--- a/.github/workflows/reporting-production.yaml
+++ b/.github/workflows/reporting-production.yaml
@@ -934,8 +934,26 @@ jobs:
       - name: "Generate date folder name"
         id: date
         shell: bash
+        env:
+          # Single source of truth for the run's date. The timestamp
+          # captured by validate-secrets at the start of the original
+          # workflow run is preserved across `Re-run failed jobs`,
+          # whereas `date -u` on the runner would yield the wall-clock
+          # date of the re-run. Anchoring the artifact folder to the
+          # original run date keeps re-runs idempotent: they refresh
+          # the original day's folder in project-reporting-artifacts
+          # rather than overwriting a later day's contents.
+          RUN_TIMESTAMP: ${{ needs.validate-secrets.outputs.run_timestamp }}
         run: |
-          DATE_FOLDER=$(date -u +%Y-%m-%d)
+          # run_timestamp is YYYY-MM-DDTHH:MM:SSZ; strip the time part.
+          DATE_FOLDER="${RUN_TIMESTAMP%%T*}"
+          if [ -z "$DATE_FOLDER" ] || \
+             ! printf '%s' "$DATE_FOLDER" | \
+             grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+            echo "::warning::run_timestamp missing or malformed" \
+              "('$RUN_TIMESTAMP'); falling back to current UTC date"
+            DATE_FOLDER=$(date -u +%Y-%m-%d)
+          fi
           echo "folder=${DATE_FOLDER}" >> "$GITHUB_OUTPUT"
           echo "Date folder: ${DATE_FOLDER}"
 

--- a/.github/workflows/reporting-production.yaml
+++ b/.github/workflows/reporting-production.yaml
@@ -591,7 +591,19 @@ jobs:
 
           echo "Raw data files prepared for upload"
 
+      # Artifact uploads tolerate transient GitHub Actions service
+      # failures (e.g. the CreateArtifact endpoint occasionally returns
+      # an HTML error page instead of JSON). Each upload uses
+      # `if: always()` so a failure in one upload step does not skip
+      # subsequent upload steps for this matrix entry. We deliberately
+      # do NOT set `continue-on-error: true` here: a true upload
+      # failure should still mark the matrix entry as failed so the
+      # summary job can surface the affected project in the Slack
+      # notification. Resilience for the rest of the run is provided
+      # by the broadened guards on the publish and
+      # copy-to-artifacts-repo jobs (`needs.analyze.result != 'skipped'`).
       - name: "Upload raw data artifacts"
+        if: always()
         # yamllint disable-line rule:line-length
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -602,6 +614,7 @@ jobs:
           compression-level: 9
 
       - name: "Upload report artifacts"
+        if: always()
         # yamllint disable-line rule:line-length
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -612,6 +625,7 @@ jobs:
           compression-level: 6
 
       - name: "Upload clone manifest"
+        if: always()
         # yamllint disable-line rule:line-length
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -623,6 +637,7 @@ jobs:
 
       - name: "Determine log file path"
         id: log-path
+        if: always()
         shell: bash
         run: |
           # Log file location based on gerrit-clone-action v0.1.14 behavior:
@@ -642,6 +657,7 @@ jobs:
           echo "Log file path: $log_path"
 
       - name: "Upload clone log"
+        if: always()
         # yamllint disable-line rule:line-length
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -653,10 +669,14 @@ jobs:
   publish:
     name: "Publish GitHub Pages"
     needs: [validate-secrets, build-matrix, analyze]
-    # Run if validation succeeded and analyze completed (even with failures)
-    # This allows publishing reports from successful matrix jobs
+    # Run if validation succeeded and analyze was not entirely skipped.
+    # We deliberately accept 'success', 'failure', and 'cancelled'
+    # (e.g. when a matrix entry never started because a runner was
+    # never assigned). Whatever artifacts were produced should still
+    # be published rather than discarded on account of one transient
+    # matrix problem.
     # yamllint disable-line rule:line-length
-    if: always() && needs.validate-secrets.result == 'success' && (needs.analyze.result == 'success' || needs.analyze.result == 'failure') && (github.event_name != 'workflow_dispatch' || inputs.skip_pages_update == false)
+    if: always() && needs.validate-secrets.result == 'success' && needs.analyze.result != 'skipped' && (github.event_name != 'workflow_dispatch' || inputs.skip_pages_update == false)
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -865,9 +885,12 @@ jobs:
   copy-to-artifacts-repo:
     name: "Transfer/Copy Artifacts"
     needs: [validate-secrets, build-matrix, analyze]
-    # Run if validation succeeded and analyze completed (even with failures)
+    # Run if validation succeeded and analyze was not entirely skipped.
+    # Mirrors the publish job: a single transient matrix failure or a
+    # matrix entry that never started must not prevent us from
+    # transferring artifacts we did successfully gather.
     # yamllint disable-line rule:line-length
-    if: always() && needs.validate-secrets.result == 'success' && (needs.analyze.result == 'success' || needs.analyze.result == 'failure') && (github.event_name != 'workflow_dispatch' || inputs.skip_artifact_transfer == false)
+    if: always() && needs.validate-secrets.result == 'success' && needs.analyze.result != 'skipped' && (github.event_name != 'workflow_dispatch' || inputs.skip_artifact_transfer == false)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Context

The scheduled Production Reports workflow run [#25907123397](https://github.com/lfreleng-actions/project-reporting-tool/actions/runs/25907123397) (2026-05-15) failed in a way that destroyed data we had successfully gathered, and the re-run on 2026-05-19 then overwrote a different day's published artifacts. This PR addresses both root causes as two atomic commits.

## Job outcomes for the failed run

| Job | Conclusion | Notes |
|---|---|---|
| Validate Secrets | success | |
| Build Matrix | success | |
| agl, lfbroadband, odl, onap, oran | success | |
| **fdio** | **failure** | `actions/upload-artifact` got an HTML error page from the GHA artifact service for five retries |
| **lfit** | **queued** (never started) | runner never assigned; `conclusion: null` |
| Publish GitHub Pages | **skipped** | guard required `analyze == success \|\| failure` |
| Transfer/Copy Artifacts | **skipped** | same guard |

Neither root cause is a bug in this repository's Python code — both are upstream GitHub Actions service-side conditions, but the workflow today amplifies them into total data loss.

## Commit 1 — Tolerate transient matrix failures

* Each `actions/upload-artifact` step in the `analyze` job now uses `if: always()`. A failure in one upload step (e.g. the raw-data upload hitting the artifact-service hiccup) no longer skips the remaining upload steps for that matrix entry, so we salvage every artifact we can for the affected project.
* **Deliberately no `continue-on-error: true`**: a true upload failure must still mark the matrix entry as `failure` so the summary job surfaces the affected project in the Slack notification. Otherwise a project's missing data would silently disappear without notification — worse than the bug we're fixing.
* The `if:` guards on `publish` and `copy-to-artifacts-repo` are broadened from `analyze == success \|\| analyze == failure` to `analyze != skipped`. A cancelled or never-started matrix entry no longer suppresses publishing and SSH transfer of the artifacts that other entries did produce. Both jobs already handle the no-artifacts case gracefully via their internal check steps.

### Downstream behaviour walkthrough

With this combination, if `fdio` fails to upload while the other 5 projects succeed:

| Stage | Before | After |
|---|---|---|
| fdio matrix entry conclusion | `failure` | `failure` |
| Other matrix entries | `success` | `success` |
| `needs.analyze.result` | `failure` | `failure` |
| Publish GitHub Pages | ran (5 projects' reports published) | runs (5 projects' reports published) |
| Transfer/Copy Artifacts | ran (5 projects' artifacts transferred) | runs (5 projects' artifacts transferred) |
| Slack notification | fires, `fdio` listed | fires, `fdio` listed |

And if a matrix entry stays `queued` (like `lfit` did), the new guard `analyze != skipped` keeps Publish + Transfer running on whatever was produced, rather than dropping everything.

## Commit 2 — Anchor artifact folder date to original run timestamp

`copy-to-artifacts-repo` computed its target folder name with `date -u +%Y-%m-%d` evaluated on the runner. When `Re-run failed jobs` was used days later, the folder name became "today" rather than the day the workflow was originally triggered, and a re-run of the 2026-05-15 run on 2026-05-19 wrote into `data/artifacts/2026-05-19/` — overwriting that day's already-published reports.

The job now reuses `needs.validate-secrets.outputs.run_timestamp` (which is preserved across `Re-run failed jobs`) and strips the date portion. This is consistent with the `generated_at` field already embedded in each report's JSON. A defensive fallback to `date -u` is retained should the upstream value ever be empty or malformed.

## Verification

* `yamllint`, `actionlint`, `gitlint`, REUSE and the rest of pre-commit clean.
* Both commits are GPG-signed and DCO-signed off.
