### PR TITLE
Fix(ci): Use sparse clone for artifact transfer

### DIFF
--- a/.github/scripts/copy-artifacts-simple.sh
+++ b/.github/scripts/copy-artifacts-simple.sh
@@ -96,14 +96,37 @@ trap cleanup EXIT
 git config --global user.name "GitHub Actions"
 git config --global user.email "actions@github.com"
 
-# Clone the repository
-log_info "Cloning ${REMOTE_REPO}..."
-if ! git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${REMOTE_REPO}.git" "$CLONE_DIR"; then
+# Clone the repository.
+#
+# project-reporting-artifacts is an append-only archive that grows by
+# hundreds of megabytes per day. A full clone checks out the entire
+# working tree, which has become large enough to exhaust the runner's
+# local disk and fail this job. Because the transfer only ever adds a
+# single new dated folder (and never reads existing folders), avoid
+# materialising the whole tree:
+#
+#   --filter=blob:none  Blobless partial clone: fetch commits and trees
+#                       but defer file contents until a checkout needs
+#                       them. GitHub honours this, so only the blobs for
+#                       the sparse paths below are downloaded.
+#   --depth=1           Shallow clone: only the tip commit is required to
+#                       stack a new commit on top.
+#   --sparse            Initialise with only top-level files present.
+log_info "Cloning ${REMOTE_REPO} (blobless, shallow, sparse)..."
+if ! git clone --filter=blob:none --depth=1 --sparse \
+    "https://x-access-token:${GITHUB_TOKEN}@github.com/${REMOTE_REPO}.git" \
+    "$CLONE_DIR"; then
     log_error "Failed to clone repository"
     exit 1
 fi
 
 cd "$CLONE_DIR"
+
+# Restrict the working tree to the target date folder only. On a fresh
+# daily run this folder does not exist yet, so nothing from history is
+# materialised; on a same-day re-run only that single day is checked out.
+log_info "Configuring sparse-checkout for ${TARGET_PATH}..."
+git sparse-checkout set "$TARGET_PATH"
 
 # Step 2: Delete existing date folder if it exists
 if [ -d "$TARGET_PATH" ]; then


### PR DESCRIPTION
## Problem

The daily **Transfer/Copy Artifacts** job in `reporting-production.yaml` has
started failing when the runner runs out of local disk space. Example failing
run:
https://github.com/lfreleng-actions/project-reporting-tool/actions/runs/27056770741/job/79874271649

## Root cause

`.github/scripts/copy-artifacts-simple.sh` performs a **full `git clone`** of
`lfreleng-actions/project-reporting-artifacts`. That repository is an
append-only archive of daily report artifacts:

- Working tree is ~31 GB under `data/artifacts/` and growing ~235 MB/day
- 130+ daily folders, ~10.8k files

A full clone checks out the **entire working tree**. A standard GitHub-hosted
`ubuntu-latest` runner has only **14 GB of SSD**, so the checkout exhausts
local storage and the job dies. This degrades further every day the archive
grows.

## Fix (this PR)

The job only ever **adds a new dated folder** (`data/artifacts/YYYY-MM-DD/`)
and never reads existing folders, so there is no need to materialise the whole
tree. The clone now uses a blobless, shallow, sparse checkout:

```bash
git clone --filter=blob:none --depth=1 --sparse "$REPO_URL" "$CLONE_DIR"
git sparse-checkout set "data/artifacts/${DATE_FOLDER}"
```

- `--filter=blob:none` — blobless partial clone (fetch commits and trees, defer
  file blobs until a checkout needs them; GitHub honours the filter)
- `--depth=1` — shallow clone (only the tip commit is required to stack a new
  commit on top)
- `--sparse` plus `git sparse-checkout set` scoped to the target date folder —
  materialise only the (new) target folder

For a fresh daily run the target folder does not exist yet, so **nothing from
history is checked out**; on a same-day re-run only that single day is
materialised. The runner footprint stays roughly constant regardless of how
large the archive becomes.

## Validation

- `bash -n` syntax check: clean
- `shellcheck` (pre-commit hook): clean
- Verified the sparse mechanics locally against a clone of the artifacts repo:
  after `git sparse-checkout set` to a non-existent future date, only the 7
  top-level files were materialised — none of the `data/artifacts/` history.

## Follow-ups (not in this PR)

The investigation surfaced larger opportunities I can raise separately:

- ~15 GB of the archive is the `raw-data-*` directories, which are
  byte-identical duplicates of files already present in `reports-*` (and the
  per-project bundle zip re-embeds the same content again). Removing the
  duplication plus a retention policy would cut growth dramatically.
- Longer term, an append-only blob archive may be better served by object
  storage (Cloudflare R2 / Backblaze B2 / S3) or GitHub Releases than a git
  working tree.
