### PR TITLE
CI(dependabot): Add 7-day update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "Chore"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 15
   - package-ecosystem: "uv"
     directory: "/"
@@ -17,6 +19,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "Chore"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 15
     exclude-paths:
       - "LICENSES/**"


### PR DESCRIPTION
Adds a 7-day `cooldown` to every enabled Dependabot ecosystem in
`.github/dependabot.yml`, satisfying the Zizmor workflow audit which
flags ecosystems that open version-bump PRs without a cooldown window.

This makes dependency bump PRs wait before opening, avoiding churn on
releases that are retracted or superseded shortly after they ship.