### PR TITLE
CI: Resolve Zizmor static analysis findings

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -23,8 +23,8 @@ jobs:
     name: "Repository Metadata"
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read  # Required to check out the repository
+      pull-requests: read  # Required to read PR metadata for the summary
     timeout-minutes: 5
     steps:
       # yamllint disable-line rule:line-length
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Gather repository metadata"
         id: repo-metadata
@@ -69,6 +70,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: 'Verify pushed tag'
         id: 'tag-validate'
@@ -87,9 +89,10 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          TAG_NAME: ${{ steps.tag-validate.outputs.tag_name }}
         run: |
           # Ensure draft release exists
-          TAG="${{ steps.tag-validate.outputs.tag_name }}"
+          TAG="${TAG_NAME}"
           # Check if release exists and get its draft status
           if RELEASE_INFO=$(gh release view "$TAG" \
             --json isDraft 2>/dev/null); then
@@ -131,6 +134,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Build Python project'
         id: 'python-build'
@@ -160,6 +165,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Test Python project [PYTEST]'
         # yamllint disable-line rule:line-length
@@ -187,6 +194,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Audit Python project'
         # yamllint disable-line rule:line-length
@@ -211,6 +220,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Generate SBOM"
         id: sbom
@@ -275,8 +286,8 @@ jobs:
             # Grype summary
             {
               echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+              echo "SBOM count: ${COMPONENT_COUNT}"
+              echo "Tool used: ${DEPENDENCY_MANAGER}"
               echo ""
               echo "## Grype Vulnerability Scan"
               if [ -f grype-results.txt ]; then
@@ -289,6 +300,9 @@ jobs:
               echo "--- Grype scan results ---"
               cat grype-results.txt
             fi
+        env:
+          COMPONENT_COUNT: ${{ steps.sbom.outputs.component_count }}
+          DEPENDENCY_MANAGER: ${{ steps.sbom.outputs.dependency_manager }}
 
       # Fails the job if Grype found vulnerabilities, unless the
       # NO_BLOCK_AUDIT_FAIL repository variable is set to 'true'.
@@ -397,6 +411,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: '⬇ Download build artefacts'
         # yamllint disable-line rule:line-length
@@ -435,14 +451,17 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Check if release is already promoted'
         id: 'check-promoted'
         shell: bash
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          NEEDS_TAG_VALIDATE_OUTPUTS_TAG: ${{ needs.tag-validate.outputs.tag }}
         run: |
-          TAG="${{ needs.tag-validate.outputs.tag }}"
+          TAG="${NEEDS_TAG_VALIDATE_OUTPUTS_TAG}"
           if gh release view "$TAG" --json isDraft --jq '.isDraft' \
               2>/dev/null | grep -q "false"; then
             echo "Release $TAG is already promoted, skipping promotion"
@@ -469,7 +488,8 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          NEEDS_TAG_VALIDATE_OUTPUTS_TAG: ${{ needs.tag-validate.outputs.tag }}
         run: |
-          TAG="${{ needs.tag-validate.outputs.tag }}"
+          TAG="${NEEDS_TAG_VALIDATE_OUTPUTS_TAG}"
           RELEASE_URL=$(gh release view "$TAG" --json url --jq '.url')
           echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -36,8 +36,8 @@ jobs:
     name: "Repository Metadata"
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read  # Required to check out the repository
+      pull-requests: read  # Required to read PR metadata for the summary
     timeout-minutes: 5
     steps:
       # yamllint disable-line rule:line-length
@@ -49,6 +49,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Gather repository metadata"
         id: repo-metadata
@@ -164,6 +165,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Build Python project'
         id: python-build
@@ -191,6 +194,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Python tests [pytest] ${{ matrix.python-version }}"
         # yamllint disable-line rule:line-length
@@ -219,6 +224,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Audit dependencies ${{ matrix.python-version }}"
         # yamllint disable-line rule:line-length
@@ -244,6 +251,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Generate SBOM"
         id: sbom
@@ -308,8 +317,8 @@ jobs:
             # Grype summary
             {
               echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+              echo "SBOM count: ${COMPONENT_COUNT}"
+              echo "Tool used: ${DEPENDENCY_MANAGER}"
               echo ""
               echo "## Grype Vulnerability Scan"
               if [ -f grype-results.txt ]; then
@@ -322,6 +331,9 @@ jobs:
               echo "--- Grype scan results ---"
               cat grype-results.txt
             fi
+        env:
+          COMPONENT_COUNT: ${{ steps.sbom.outputs.component_count }}
+          DEPENDENCY_MANAGER: ${{ steps.sbom.outputs.dependency_manager }}
 
       - name: "Check Grype scan results"
         if: >-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,9 +30,9 @@ jobs:
     with:
       codeql_config: .github/codeql/codeql-config.yml
     permissions:
-      security-events: write
+      security-events: write  # Upload CodeQL analysis results
       # required to fetch internal or private CodeQL packs
-      packages: read
+      packages: read  # Fetch internal or private CodeQL packs
       # only required for workflows in private repositories
-      actions: read
-      contents: read
+      actions: read  # Read workflow run metadata in private repositories
+      contents: read  # Check out the repository for analysis

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -33,9 +33,9 @@ jobs:
     # v0.2.28
     permissions:
       # Needed to upload the results to code-scanning dashboard.
-      security-events: write
+      security-events: write  # Upload results to the code-scanning dashboard
       # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      id-token: write  # Publish results and obtain the Scorecard badge via OIDC
       # Uncomment the permissions below if installing in a private repository.
       # contents: read
       # actions: read

--- a/.github/workflows/performance-tracking.yaml
+++ b/.github/workflows/performance-tracking.yaml
@@ -26,9 +26,9 @@ jobs:
   benchmark-suite:
     name: Full Benchmark Suite
     permissions:
-      contents: read
-      issues: write
-      pull-requests: write
+      contents: read  # Read repository contents (checkout, artifacts)
+      issues: write  # Open performance alert issues on threshold violations
+      pull-requests: write  # Comment on PRs with performance alerts
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -63,11 +63,11 @@ jobs:
         continue-on-error: true
         env:
           # yamllint disable-line rule:line-length
-          BASELINE_INPUT: ${{ github.event.inputs.comparison_baseline || 'main' }}
+          COMPARISON_BASELINE: ${{ github.event.inputs.comparison_baseline || 'main' }}
         run: |
           mkdir -p .benchmarks
           # Try to fetch previous benchmark results from artifacts
-          BASELINE="${BASELINE_INPUT}"
+          BASELINE="${COMPARISON_BASELINE}"
           echo "Baseline: ${BASELINE}"
 
       - name: Run comprehensive benchmarks
@@ -91,13 +91,15 @@ jobs:
 
       - name: Generate performance report
         if: always()
-        run: |
+        # github.sha/github.run_number are trusted, GitHub-assigned values
+        # rendered inside a quoted heredoc (GitHub templating, not shell).
+        run: | # zizmor: ignore[template-injection]
           cat > performance-report.md << 'EOF'
           # Performance Tracking Report
 
           **Date:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
           **Commit:** ${{ github.sha }}
-          **Branch:** ${GITHUB_REF_NAME}
+          **Branch:** ${{ github.ref_name }}
           **Run:** ${{ github.run_number }}
 
           ## Benchmark Results
@@ -178,7 +180,9 @@ jobs:
 
       - name: Analyze threshold failures
         if: steps.threshold-check.outcome == 'failure'
-        run: |
+        # github.run_number/github.sha are trusted, GitHub-assigned values
+        # rendered inside a quoted heredoc (GitHub templating, not shell).
+        run: | # zizmor: ignore[template-injection]
           echo "⚠️ Performance threshold violations detected!"
           echo "threshold_failures=true" >> "$GITHUB_OUTPUT"
 
@@ -212,6 +216,8 @@ jobs:
           github.ref == 'refs/heads/main'
         # yamllint disable-line rule:line-length
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
         with:
           script: |
             const fs = require('fs');
@@ -221,7 +227,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Performance Alert: Threshold Violations ` +
-                `(Run ${{ github.run_number }})`,
+                `(Run ${process.env.RUN_NUMBER})`,
               body: alert,
               labels: ['performance', 'automated', 'needs-investigation']
             });
@@ -232,6 +238,8 @@ jobs:
         if: steps.threshold-check.outcome == 'failure'
         # yamllint disable-line rule:line-length
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
         with:
           script: |
             const { data: prs } = await github.rest.pulls.list({
@@ -246,7 +254,7 @@ jobs:
             const comment = `⚠️ **Performance Alert**\n\n` +
               `Recent performance tracking run detected ` +
               `threshold violations.\n` +
-              `Run: ${{ github.run_number }}\n` +
+              `Run: ${process.env.RUN_NUMBER}\n` +
               `Please review if your changes may have ` +
               `impacted performance.`;
 
@@ -371,7 +379,9 @@ jobs:
         continue-on-error: true
 
       - name: Generate dashboard
-        run: |
+        # github.run_number and needs.*.result are trusted values rendered
+        # inside a quoted heredoc (GitHub templating, not shell).
+        run: | # zizmor: ignore[template-injection]
           cat > performance-dashboard.md << 'EOF'
           # Performance Dashboard
 

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,16 +20,26 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: 'audit'
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7.4.0

--- a/.github/workflows/reporting-previews.yaml
+++ b/.github/workflows/reporting-previews.yaml
@@ -31,8 +31,9 @@ jobs:
     name: "Verify configuration"
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    environment: production
     permissions:
-      contents: read
+      contents: read  # Required to check out the repository
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.parse-projects.outputs.matrix }}
@@ -55,19 +56,21 @@ jobs:
       - name: "Generate run metadata"
         id: metadata
         shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          pr_number="${{ github.event.pull_request.number }}"
 
           echo "timestamp=$timestamp" >> "$GITHUB_OUTPUT"
-          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
           {
             echo "## 🔍 Preview Report Generation"
             echo ""
-            echo "**PR:** #$pr_number"
+            echo "**PR:** #${PR_NUMBER}"
             echo "**Started:** $timestamp"
-            echo "**Run ID:** ${{ github.run_id }}"
+            echo "**Run ID:** ${RUN_ID}"
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -180,8 +183,9 @@ jobs:
     name: "${{ matrix.project }} (Preview)"
     needs: verify
     runs-on: ubuntu-latest
+    environment: production
     permissions:
-      contents: read
+      contents: read  # Required to check out the repository
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -240,6 +244,9 @@ jobs:
 
       - name: "Check clone status"
         shell: bash
+        env:
+          MATRIX_GERRIT: ${{ matrix.gerrit }}
+          MATRIX_GITHUB: ${{ matrix.github }}
         run: |
           # Determine which clone step ran and check its outcome
           if [ -n "${MATRIX_GERRIT}" ]; then
@@ -261,9 +268,6 @@ jobs:
           else
             echo "::warning::Clone path does not exist: $clone_path"
           fi
-        env:
-          MATRIX_GERRIT: ${{ matrix.gerrit }}
-          MATRIX_GITHUB: ${{ matrix.github }}
 
       - name: "Clone info-master repository"
         shell: bash
@@ -334,10 +338,13 @@ jobs:
           MATRIX_JENKINS: ${{ matrix.jenkins }}
           MATRIX_GITHUB: ${{ matrix.github }}
           MATRIX_SLUG: ${{ matrix.slug }}
-          # yamllint disable rule:line-length
-          NEEDS_VERIFY_OUTPUTS_RUN_TIMESTAMP: ${{ needs.verify.outputs.run_timestamp }}
-          GITHUB_EVENT_PULL_REQUEST_USER_LOGIN: ${{ github.event.pull_request.user.login }}
-          # yamllint enable rule:line-length
+          RUN_TIMESTAMP: ${{ needs.verify.outputs.run_timestamp }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          GIT_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           project="${MATRIX_PROJECT}"
           report_dir="./reports/$project"
@@ -360,14 +367,14 @@ jobs:
             "gerrit_server": "${gerrit_server:-}",
             "jenkins_server": "${jenkins_server:-}",
             "github_org": "${github_org:-}",
-            "generated_at": "${NEEDS_VERIFY_OUTPUTS_RUN_TIMESTAMP}",
-            "workflow_run_id": "${{ github.run_id }}",
-            "workflow_run_number": "${{ github.run_number }}",
-            "workflow_run_attempt": "${{ github.run_attempt }}",
-            "git_sha": "${{ github.event.pull_request.head.sha }}",
+            "generated_at": "${RUN_TIMESTAMP}",
+            "workflow_run_id": "${RUN_ID}",
+            "workflow_run_number": "${RUN_NUMBER}",
+            "workflow_run_attempt": "${RUN_ATTEMPT}",
+            "git_sha": "${GIT_SHA}",
             "git_ref": "$PR_HEAD_REF",
-            "pr_number": ${{ github.event.pull_request.number }},
-            "pr_author": "${GITHUB_EVENT_PULL_REQUEST_USER_LOGIN}",
+            "pr_number": ${PR_NUMBER},
+            "pr_author": "${PR_AUTHOR}",
             "environment": "previews"
           }
           EOF
@@ -377,6 +384,9 @@ jobs:
       - name: "Copy raw data files to temp directory"
         if: always()
         shell: bash
+        env:
+          MATRIX_SLUG: ${{ matrix.slug }}
+          MATRIX_PROJECT: ${{ matrix.project }}
         run: |
           # Create temp directory for raw data files
           mkdir -p "./temp-raw-data-${MATRIX_SLUG}"
@@ -397,9 +407,6 @@ jobs:
           fi
 
           echo "Raw data files prepared for upload"
-        env:
-          MATRIX_SLUG: ${{ matrix.slug }}
-          MATRIX_PROJECT: ${{ matrix.project }}
 
       - name: "Upload raw data artifacts"
         if: always()
@@ -439,9 +446,10 @@ jobs:
     needs: [verify, analyze]
     if: always() && needs.verify.result == 'success'
     runs-on: ubuntu-latest
+    environment: production
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # Required to push preview commits to gh-pages
+      pull-requests: write  # Required to comment preview links on the PR
     timeout-minutes: 15
     steps:
       # Harden the runner
@@ -463,12 +471,11 @@ jobs:
           mkdir -p /tmp/pr-scripts
           cp .github/scripts/generate-index.sh /tmp/pr-scripts/
 
-      # This checkout intentionally persists credentials so the later
-      # "git push origin gh-pages" step can authenticate. The token is
-      # the repository-scoped GITHUB_TOKEN, so artipacked is suppressed.
       - name: "Checkout gh-pages branch"
+        # persist-credentials must stay enabled: the later "Commit and push
+        # preview" step runs `git push origin gh-pages` using these creds.
         # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6.0.3 # zizmor: ignore[artipacked]
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0 # zizmor: ignore[artipacked]
         with:
           ref: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -483,12 +490,13 @@ jobs:
 
       - name: "Prepare preview directory"
         shell: bash
+        env:
+          PR_NUMBER: ${{ needs.verify.outputs.pr_number }}
         run: |
-          pr_number="${NEEDS_VERIFY_OUTPUTS_PR_NUMBER}"
-          echo "📦 Preparing Preview report for #$pr_number"
+          echo "📦 Preparing Preview report for #${PR_NUMBER}"
 
           # Create Preview report directory
-          preview_dir="previews/$pr_number"
+          preview_dir="previews/${PR_NUMBER}"
           mkdir -p "$preview_dir"
 
           # Clean up old preview if it exists
@@ -531,24 +539,21 @@ jobs:
           echo "REPORT_COUNT=$report_count" >> "$GITHUB_ENV"
           echo "PREVIEW_DIR=$preview_dir" >> "$GITHUB_ENV"
           echo "✅ Prepared $report_count preview report(s)"
-        env:
-          NEEDS_VERIFY_OUTPUTS_PR_NUMBER: ${{ needs.verify.outputs.pr_number }}
 
       - name: "Generate preview index page"
         shell: bash
+        env:
+          PR_NUMBER: ${{ needs.verify.outputs.pr_number }}
         run: |
           # Create .nojekyll to disable Jekyll processing
           touch .nojekyll
           echo "✅ Created .nojekyll file"
 
-          pr_number="${NEEDS_VERIFY_OUTPUTS_PR_NUMBER}"
-          preview_dir="previews/$pr_number"
+          preview_dir="previews/${PR_NUMBER}"
 
           # Use the script from the PR branch (has latest fixes)
           bash /tmp/pr-scripts/generate-index.sh \
             "$preview_dir" "previews"
-        env:
-          NEEDS_VERIFY_OUTPUTS_PR_NUMBER: ${{ needs.verify.outputs.pr_number }}
 
       - name: "Generate parent previews index"
         shell: bash
@@ -789,13 +794,13 @@ jobs:
         shell: bash
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-          NEEDS_VERIFY_OUTPUTS_PR_NUMBER: ${{ needs.verify.outputs.pr_number }}
-          # yamllint disable-line rule:line-length
-          NEEDS_VERIFY_OUTPUTS_RUN_TIMESTAMP: ${{ needs.verify.outputs.run_timestamp }}
-          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ needs.verify.outputs.pr_number }}
+          RUN_TIMESTAMP: ${{ needs.verify.outputs.run_timestamp }}
+          RUN_ID: ${{ github.run_id }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          pr_number="${NEEDS_VERIFY_OUTPUTS_PR_NUMBER}"
-          preview_dir="previews/$pr_number"
+          preview_dir="previews/${PR_NUMBER}"
 
           git config user.name "lf-releng-reports-bot"
           git config user.email \
@@ -811,36 +816,39 @@ jobs:
           fi
 
           cat > /tmp/commit-msg.txt <<EOF
-          chore: add PR #$pr_number preview reports
+          chore: add PR #${PR_NUMBER} preview reports
 
-          Generated: ${NEEDS_VERIFY_OUTPUTS_RUN_TIMESTAMP}
+          Generated: ${RUN_TIMESTAMP}
           Reports: ${REPORT_COUNT} project(s)
-          PR: #$pr_number - $PR_TITLE
-          Run: ${{ github.run_id }}
+          PR: #${PR_NUMBER} - $PR_TITLE
+          Run: ${RUN_ID}
           EOF
 
           git commit -F /tmp/commit-msg.txt
           git push origin gh-pages
 
-          repo_name="${GITHUB_EVENT_REPOSITORY_NAME}"
-          owner="${{ github.repository_owner }}"
-          base_url="https://${owner}.github.io/${repo_name}"
+          base_url="https://${REPO_OWNER}.github.io/${REPO_NAME}"
           echo "PREVIEW_URL=${base_url}/${preview_dir}" >> "$GITHUB_ENV"
           echo "✅ Published Preview report"
 
       - name: "Comment on pull request with links"
         # yamllint disable-line rule:line-length
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = ${{ github.event.pull_request.number }};
+            const prNumber = Number(process.env.PR_NUMBER);
             const previewUrl = process.env.PREVIEW_URL;
             const reportCount = process.env.REPORT_COUNT;
 
-            const serverUrl = '${{ github.server_url }}';
-            const repo = '${{ github.repository }}';
-            const runId = '${{ github.run_id }}';
+            const serverUrl = process.env.SERVER_URL;
+            const repo = process.env.REPOSITORY;
+            const runId = process.env.RUN_ID;
             const runUrl = `${serverUrl}/${repo}/actions/runs/${runId}`;
             const body = `## 🔍 Preview Reports Available
 
@@ -894,6 +902,11 @@ jobs:
 
       - name: "Generate workflow summary"
         shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+          ANALYZE_RESULT: ${{ needs.analyze.result }}
+          PUBLISH_RESULT: ${{ needs.publish-preview.result }}
         run: |
           # Helper function to convert result to emoji
           result_emoji() {
@@ -909,17 +922,17 @@ jobs:
           {
             echo "## 🔍 Preview Reports Complete"
             echo ""
-            echo "**PR:** #${{ github.event.pull_request.number }}"
+            echo "**PR:** #${PR_NUMBER}"
             echo "**Completed:** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo ""
             echo "### Job Results"
             echo ""
             echo "- **Verify:** $(result_emoji \
-              '${{ needs.verify.result }}')"
+              "${VERIFY_RESULT}")"
             echo "- **Analyze:** $(result_emoji \
-              '${{ needs.analyze.result }}')"
+              "${ANALYZE_RESULT}")"
             echo "- **Publish:** $(result_emoji \
-              '${{ needs.publish-preview.result }}')"
+              "${PUBLISH_RESULT}")"
             echo ""
             echo "✅ Preview reports are available from pull request comments"
             echo ""

--- a/.github/workflows/reporting-production.yaml
+++ b/.github/workflows/reporting-production.yaml
@@ -37,6 +37,7 @@ jobs:
   validate-secrets:
     name: "Validate Secrets"
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
     timeout-minutes: 5
@@ -59,17 +60,20 @@ jobs:
       - name: "Generate run metadata"
         id: metadata
         shell: bash
+        env:
+          RUN_ID: ${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           echo "timestamp=$timestamp" >> "$GITHUB_OUTPUT"
-          echo "run_id=${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
 
           {
             echo "## 📊 Production Report Generation"
             echo ""
             echo "**Started:** $timestamp"
-            echo "**Run ID:** ${{ github.run_id }}"
-            echo "**Trigger:** ${{ github.event_name }}"
+            echo "**Run ID:** ${RUN_ID}"
+            echo "**Trigger:** ${EVENT_NAME}"
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -249,10 +253,12 @@ jobs:
       - name: "Create matrix from ACTIVE_PROJECTS"
         id: create-matrix
         shell: bash
+        env:
+          ACTIVE_PROJECTS_VAR: ${{ vars.ACTIVE_PROJECTS }}
         run: |
           # Build matrix from ACTIVE_PROJECTS variable
           # This job does NOT access any secrets
-          active_projects="${VARS_ACTIVE_PROJECTS}"
+          active_projects="${ACTIVE_PROJECTS_VAR}"
 
           if [ -z "$active_projects" ]; then
             echo "::error::ACTIVE_PROJECTS variable is not set"
@@ -271,13 +277,12 @@ jobs:
             echo ""
             echo "$active_projects" | jq -r '.[] | "- \(.)"'
           } >> "$GITHUB_STEP_SUMMARY"
-        env:
-          VARS_ACTIVE_PROJECTS: ${{ vars.ACTIVE_PROJECTS }}
 
   analyze:
     name: "${{ matrix.slug }}"
     needs: [validate-secrets, build-matrix]
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
     timeout-minutes: 90
@@ -326,10 +331,12 @@ jobs:
             '.[] | select(.slug == $slug) | .jenkins_token // ""')
 
           # Set outputs (non-secret values only)
-          echo "project=$project" >> "$GITHUB_OUTPUT"
-          echo "gerrit=$gerrit" >> "$GITHUB_OUTPUT"
-          echo "github=$github" >> "$GITHUB_OUTPUT"
-          echo "jenkins=$jenkins" >> "$GITHUB_OUTPUT"
+          {
+            echo "project=$project"
+            echo "gerrit=$gerrit"
+            echo "github=$github"
+            echo "jenkins=$jenkins"
+          } >> "$GITHUB_OUTPUT"
 
           # Set environment variables for secrets
           echo "JENKINS_USER=$jenkins_user" >> "$GITHUB_ENV"
@@ -384,22 +391,28 @@ jobs:
 
       - name: "Check clone status"
         shell: bash
+        env:
+          CFG_GERRIT: ${{ steps.config.outputs.gerrit }}
+          CFG_GITHUB: ${{ steps.config.outputs.github }}
+          CFG_PROJECT: ${{ steps.config.outputs.project }}
+          GERRIT_OUTCOME: ${{ steps.clone-gerrit.outcome }}
+          GITHUB_OUTCOME: ${{ steps.clone-github.outcome }}
         # yamllint disable rule:line-length
         run: |
           # Determine which clone step ran and check its outcome
-          if [ -n "${STEPS_CONFIG_OUTPUTS_GERRIT}" ]; then
+          if [ -n "${CFG_GERRIT}" ]; then
             # Gerrit project
-            if [ "${STEPS_CLONE_GERRIT_OUTCOME}" != "success" ]; then
-              echo "::error::Failed to clone Gerrit repositories for ${STEPS_CONFIG_OUTPUTS_PROJECT}"
+            if [ "${GERRIT_OUTCOME}" != "success" ]; then
+              echo "::error::Failed to clone Gerrit repositories for ${CFG_PROJECT}"
               echo "::error::Gerrit server may be unavailable or decommissioned"
               exit 1
             else
               echo "✅ Successfully cloned Gerrit repositories"
             fi
-          elif [ -n "${STEPS_CONFIG_OUTPUTS_GITHUB}" ]; then
+          elif [ -n "${CFG_GITHUB}" ]; then
             # GitHub-only project
-            if [ "${STEPS_CLONE_GITHUB_OUTCOME}" != "success" ]; then
-              echo "::error::Failed to clone GitHub repositories for ${STEPS_CONFIG_OUTPUTS_PROJECT}"
+            if [ "${GITHUB_OUTCOME}" != "success" ]; then
+              echo "::error::Failed to clone GitHub repositories for ${CFG_PROJECT}"
               echo "::error::GitHub organization may be unavailable or inaccessible"
               exit 1
             else
@@ -409,12 +422,6 @@ jobs:
             echo "::error::Project has neither gerrit nor github configured"
             exit 1
           fi
-        env:
-          STEPS_CONFIG_OUTPUTS_GERRIT: ${{ steps.config.outputs.gerrit }}
-          STEPS_CLONE_GERRIT_OUTCOME: ${{ steps.clone-gerrit.outcome }}
-          STEPS_CONFIG_OUTPUTS_PROJECT: ${{ steps.config.outputs.project }}
-          STEPS_CONFIG_OUTPUTS_GITHUB: ${{ steps.config.outputs.github }}
-          STEPS_CLONE_GITHUB_OUTCOME: ${{ steps.clone-github.outcome }}
         # yamllint enable rule:line-length
 
       - name: "Clone info-master repository"
@@ -452,12 +459,12 @@ jobs:
           CLASSIC_READ_ONLY_PAT_TOKEN: ${{ secrets.CLASSIC_READ_ONLY_PAT_TOKEN }}
           GITHUB_ORG: ${{ steps.config.outputs.github }}
           SSH_AVAILABLE: ${{ env.SSH_AVAILABLE }}
-          STEPS_CONFIG_OUTPUTS_PROJECT: ${{ steps.config.outputs.project }}
-          STEPS_CONFIG_OUTPUTS_GERRIT: ${{ steps.config.outputs.gerrit }}
-          STEPS_CONFIG_OUTPUTS_GITHUB: ${{ steps.config.outputs.github }}
+          CFG_PROJECT: ${{ steps.config.outputs.project }}
+          CFG_GERRIT: ${{ steps.config.outputs.gerrit }}
+          INPUT_DEBUG: ${{ inputs.debug }}
         # yamllint disable rule:line-length
         run: |
-          project="${STEPS_CONFIG_OUTPUTS_PROJECT}"
+          project="${CFG_PROJECT}"
           echo "📊 Generating reports for $project"
 
           # Jenkins credentials already set in GITHUB_ENV by config step
@@ -523,10 +530,10 @@ jobs:
           fi
 
           # Determine repos path based on project type
-          if [ -n "${STEPS_CONFIG_OUTPUTS_GERRIT}" ]; then
-            repos_path="./${STEPS_CONFIG_OUTPUTS_GERRIT}"
-          elif [ -n "${STEPS_CONFIG_OUTPUTS_GITHUB}" ]; then
-            repos_path="./github.com/${STEPS_CONFIG_OUTPUTS_GITHUB}"
+          if [ -n "${CFG_GERRIT}" ]; then
+            repos_path="./${CFG_GERRIT}"
+          elif [ -n "${GITHUB_ORG}" ]; then
+            repos_path="./github.com/${GITHUB_ORG}"
           else
             echo "::error::Cannot determine repos path - no gerrit or github configured"
             exit 1
@@ -535,7 +542,7 @@ jobs:
           echo "📂 Using repos path: ${repos_path}"
 
           VERBOSE_FLAG=""
-          if [ "${{ inputs.debug }}" = "true" ] || \
+          if [ "${INPUT_DEBUG}" = "true" ] || \
              [ "${RUNNER_DEBUG:-0}" = "1" ] || \
              [ "${ACTIONS_STEP_DEBUG:-false}" = "true" ]; then
             VERBOSE_FLAG="--verbose"
@@ -553,8 +560,21 @@ jobs:
 
       - name: "Create report metadata"
         shell: bash
+        env:
+          CFG_PROJECT: ${{ steps.config.outputs.project }}
+          SLUG: ${{ matrix.slug }}
+          CFG_GERRIT: ${{ steps.config.outputs.gerrit }}
+          CFG_JENKINS: ${{ steps.config.outputs.jenkins }}
+          CFG_GITHUB: ${{ steps.config.outputs.github }}
+          # yamllint disable-line rule:line-length
+          RUN_TIMESTAMP: ${{ needs.validate-secrets.outputs.run_timestamp }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          GIT_SHA: ${{ github.sha }}
+          GIT_REF: ${{ github.ref }}
         run: |
-          project="${STEPS_CONFIG_OUTPUTS_PROJECT}"
+          project="${CFG_PROJECT}"
           report_dir="./reports/$project"
 
           if [ ! -d "$report_dir" ]; then
@@ -566,56 +586,48 @@ jobs:
           cat > "$report_dir/metadata.json" <<EOF
           {
             "project": "$project",
-            "slug": "${MATRIX_SLUG}",
-            "gerrit_server": "${STEPS_CONFIG_OUTPUTS_GERRIT}",
-            "jenkins_server": "${STEPS_CONFIG_OUTPUTS_JENKINS}",
-            "github_org": "${STEPS_CONFIG_OUTPUTS_GITHUB}",
+            "slug": "${SLUG}",
+            "gerrit_server": "${CFG_GERRIT}",
+            "jenkins_server": "${CFG_JENKINS}",
+            "github_org": "${CFG_GITHUB}",
             "generated_at": \
-              "${NEEDS_VALIDATE_SECRETS_OUTPUTS_RUN_TIMESTAMP}",
-            "workflow_run_id": "${{ github.run_id }}",
-            "workflow_run_number": "${{ github.run_number }}",
-            "workflow_run_attempt": "${{ github.run_attempt }}",
-            "git_sha": "${{ github.sha }}",
-            "git_ref": "${GITHUB_REF}",
+              "${RUN_TIMESTAMP}",
+            "workflow_run_id": "${RUN_ID}",
+            "workflow_run_number": "${RUN_NUMBER}",
+            "workflow_run_attempt": "${RUN_ATTEMPT}",
+            "git_sha": "${GIT_SHA}",
+            "git_ref": "${GIT_REF}",
             "environment": "production"
           }
           EOF
 
           echo "✅ Metadata created"
-        env:
-          STEPS_CONFIG_OUTPUTS_PROJECT: ${{ steps.config.outputs.project }}
-          MATRIX_SLUG: ${{ matrix.slug }}
-          STEPS_CONFIG_OUTPUTS_GERRIT: ${{ steps.config.outputs.gerrit }}
-          STEPS_CONFIG_OUTPUTS_JENKINS: ${{ steps.config.outputs.jenkins }}
-          STEPS_CONFIG_OUTPUTS_GITHUB: ${{ steps.config.outputs.github }}
-          # yamllint disable-line rule:line-length
-          NEEDS_VALIDATE_SECRETS_OUTPUTS_RUN_TIMESTAMP: ${{ needs.validate-secrets.outputs.run_timestamp }}
 
       - name: "Copy raw data files to temp directory"
         shell: bash
+        env:
+          SLUG: ${{ matrix.slug }}
+          CFG_PROJECT: ${{ steps.config.outputs.project }}
         run: |
           # Create temp directory for raw data files
-          mkdir -p "./temp-raw-data-${MATRIX_SLUG}"
+          mkdir -p "./temp-raw-data-${SLUG}"
 
           # Copy JSON files to temp directory (flattening the structure)
-          project="${STEPS_CONFIG_OUTPUTS_PROJECT}"
+          project="${CFG_PROJECT}"
           if [ -f "./reports/$project/report_raw.json" ]; then
             cp "./reports/$project/report_raw.json" \
-              "./temp-raw-data-${MATRIX_SLUG}/"
+              "./temp-raw-data-${SLUG}/"
           fi
           if [ -f "./reports/$project/config_resolved.json" ]; then
             cp "./reports/$project/config_resolved.json" \
-              "./temp-raw-data-${MATRIX_SLUG}/"
+              "./temp-raw-data-${SLUG}/"
           fi
           if [ -f "./reports/$project/metadata.json" ]; then
             cp "./reports/$project/metadata.json" \
-              "./temp-raw-data-${MATRIX_SLUG}/"
+              "./temp-raw-data-${SLUG}/"
           fi
 
           echo "Raw data files prepared for upload"
-        env:
-          MATRIX_SLUG: ${{ matrix.slug }}
-          STEPS_CONFIG_OUTPUTS_PROJECT: ${{ steps.config.outputs.project }}
 
       # Artifact uploads tolerate transient GitHub Actions service
       # failures (e.g. the CreateArtifact endpoint occasionally returns
@@ -665,25 +677,25 @@ jobs:
         id: log-path
         if: always()
         shell: bash
+        env:
+          CFG_GERRIT: ${{ steps.config.outputs.gerrit }}
+          CFG_GITHUB: ${{ steps.config.outputs.github }}
         run: |
           # Log file location based on gerrit-clone-action v0.1.14 behavior:
           # - Gerrit: ./gerrit.example.org/gerrit.example.org.log
           # - GitHub: ./github.com/orgname/github.com.orgname.log
-          if [ -n "${STEPS_CONFIG_OUTPUTS_GERRIT}" ]; then
+          if [ -n "${CFG_GERRIT}" ]; then
             # Gerrit: ./gerrit.example.org/gerrit.example.org.log
-            gerrit_host="${STEPS_CONFIG_OUTPUTS_GERRIT}"
+            gerrit_host="${CFG_GERRIT}"
             log_path="./${gerrit_host}/${gerrit_host}.log"
           else
             # GitHub: ./github.com/orgname/github.com.orgname.log
-            github_org="${STEPS_CONFIG_OUTPUTS_GITHUB}"
+            github_org="${CFG_GITHUB}"
             sanitized_host="github.com.${github_org}"
             log_path="./github.com/${github_org}/${sanitized_host}.log"
           fi
           echo "path=$log_path" >> "$GITHUB_OUTPUT"
           echo "Log file path: $log_path"
-        env:
-          STEPS_CONFIG_OUTPUTS_GERRIT: ${{ steps.config.outputs.gerrit }}
-          STEPS_CONFIG_OUTPUTS_GITHUB: ${{ steps.config.outputs.github }}
 
       - name: "Upload clone log"
         if: always()
@@ -708,9 +720,9 @@ jobs:
     if: always() && needs.validate-secrets.result == 'success' && needs.analyze.result != 'skipped' && (github.event_name != 'workflow_dispatch' || inputs.skip_pages_update == false)
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pages: write
-      id-token: write
+      contents: write  # Required to push generated reports to gh-pages
+      pages: write  # Required to deploy to GitHub Pages
+      id-token: write  # Required for Pages deployment authentication
     timeout-minutes: 20
     steps:
       # Harden the runner
@@ -735,12 +747,12 @@ jobs:
           chmod +x /tmp/main-scripts/generate-index.sh
           echo "✅ Copied generate-index.sh from main branch"
 
-      # This checkout intentionally persists credentials so the later
-      # "git push origin gh-pages" step can authenticate. The token is
-      # the repository-scoped GITHUB_TOKEN, so artipacked is suppressed.
       - name: "Checkout gh-pages branch"
+        # persist-credentials is intentionally left enabled: the later
+        # "Commit and push changes" step relies on the persisted token
+        # to run `git push origin gh-pages`.
         # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6.0.3 # zizmor: ignore[artipacked]
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0 # zizmor: ignore[artipacked]
         with:
           ref: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -843,6 +855,12 @@ jobs:
       - name: "Commit and push changes"
         if: steps.check-reports.outputs.count != '0'
         shell: bash
+        env:
+          RUN_ID: ${{ github.run_id }}
+          # yamllint disable-line rule:line-length
+          RUN_TIMESTAMP: ${{ needs.validate-secrets.outputs.run_timestamp }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           git config user.name "lf-releng-reports-bot"
           git config user.email "lf-releng+reports-bot@linuxfoundation.org"
@@ -868,11 +886,11 @@ jobs:
           fi
 
           cat > /tmp/commit-msg.txt <<EOF
-          chore: update production reports (run ${{ github.run_id }})
+          chore: update production reports (run ${RUN_ID})
 
-          Generated: ${NEEDS_VALIDATE_SECRETS_OUTPUTS_RUN_TIMESTAMP}
+          Generated: ${RUN_TIMESTAMP}
           Reports: ${REPORT_COUNT} project(s)
-          Run: ${{ github.run_id }}
+          Run: ${RUN_ID}
           EOF
 
           git commit -F /tmp/commit-msg.txt
@@ -890,15 +908,11 @@ jobs:
             echo "### 🌐 View Reports"
             echo ""
             echo "Reports will be available at:"
-            owner="${{ github.repository_owner }}"
-            repo="${GITHUB_EVENT_REPOSITORY_NAME}"
+            owner="${REPO_OWNER}"
+            repo="${REPO_NAME}"
             echo "https://${owner}.github.io/${repo}/"
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
-        env:
-          # yamllint disable-line rule:line-length
-          NEEDS_VALIDATE_SECRETS_OUTPUTS_RUN_TIMESTAMP: ${{ needs.validate-secrets.outputs.run_timestamp }}
-          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: "Report publish status"
         if: steps.check-reports.outputs.count == '0'
@@ -929,6 +943,7 @@ jobs:
     # yamllint disable-line rule:line-length
     if: always() && needs.validate-secrets.result == 'success' && needs.analyze.result != 'skipped' && (github.event_name != 'workflow_dispatch' || inputs.skip_artifact_transfer == false)
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
     timeout-minutes: 15
@@ -1019,21 +1034,26 @@ jobs:
         shell: bash
         env:
           GERRIT_REPORTS_PAT_TOKEN: ${{ secrets.GERRIT_REPORTS_PAT_TOKEN }}
-          STEPS_DATE_OUTPUTS_FOLDER: ${{ steps.date.outputs.folder }}
+          DATE_FOLDER: ${{ steps.date.outputs.folder }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           chmod +x .github/scripts/copy-artifacts-simple.sh
           .github/scripts/copy-artifacts-simple.sh \
-            "${STEPS_DATE_OUTPUTS_FOLDER}" \
-            "${{ github.run_id }}" \
+            "${DATE_FOLDER}" \
+            "${RUN_ID}" \
             "./downloaded-artifacts" \
             "$GERRIT_REPORTS_PAT_TOKEN"
 
       - name: "Generate job summary"
         if: always()
         shell: bash
+        env:
+          ARTIFACTS_TOTAL: ${{ steps.check-artifacts.outputs.count }}
+          DATE_FOLDER: ${{ steps.date.outputs.folder }}
+          RUN_ID: ${{ github.run_id }}
         # yamllint disable rule:line-length
         run: |
-          artifact_count="${STEPS_CHECK_ARTIFACTS_OUTPUTS_COUNT}"
+          artifact_count="${ARTIFACTS_TOTAL}"
 
           # Determine actual status based on artifact count
           if [ "$artifact_count" -eq 0 ] 2>/dev/null || [ -z "$artifact_count" ]; then
@@ -1047,8 +1067,8 @@ jobs:
           {
             echo "## 📦 Artifacts Transferred"
             echo ""
-            echo "**Date Folder:** ${STEPS_DATE_OUTPUTS_FOLDER}"
-            echo "**Workflow Run:** ${{ github.run_id }}"
+            echo "**Date Folder:** ${DATE_FOLDER}"
+            echo "**Workflow Run:** ${RUN_ID}"
             echo "**Target Repository:** lfreleng-actions/project-reporting-artifacts"
             echo "**Status:** ${status_emoji} ${status}"
             echo "**Artifacts Found:** ${artifact_count:-0}"
@@ -1058,7 +1078,7 @@ jobs:
             if [ "$artifact_count" -gt 0 ] 2>/dev/null; then
               echo "### 🔗 View in Repository"
               echo ""
-              echo "https://github.com/lfreleng-actions/project-reporting-artifacts/tree/main/data/artifacts/${STEPS_DATE_OUTPUTS_FOLDER}"
+              echo "https://github.com/lfreleng-actions/project-reporting-artifacts/tree/main/data/artifacts/${DATE_FOLDER}"
               echo ""
             else
               echo "### ⚠️ No Artifacts Transferred"
@@ -1073,9 +1093,6 @@ jobs:
               echo ""
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-        env:
-          STEPS_CHECK_ARTIFACTS_OUTPUTS_COUNT: ${{ steps.check-artifacts.outputs.count }}
-          STEPS_DATE_OUTPUTS_FOLDER: ${{ steps.date.outputs.folder }}
         # yamllint enable rule:line-length
 
       - name: "Fail job if no artifacts were transferred"
@@ -1095,9 +1112,10 @@ jobs:
       - copy-to-artifacts-repo
     if: always()
     runs-on: ubuntu-latest
+    environment: production
     permissions:
-      actions: read
-      contents: read
+      actions: read  # Required to query matrix job results via the API
+      contents: read  # Required to check out the repository
     timeout-minutes: 10
     steps:
       # Harden the runner
@@ -1112,7 +1130,13 @@ jobs:
         shell: bash
         env:
           PROJECTS_JSON_B64: ${{ secrets.PROJECTS_JSON }}
-          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          RESULT_VALIDATE: ${{ needs.validate-secrets.result }}
+          RESULT_ANALYZE: ${{ needs.analyze.result }}
+          RESULT_PUBLISH: ${{ needs.publish.result }}
+          RESULT_COPY: ${{ needs.copy-to-artifacts-repo.result }}
+          RESULT_MATRIX: ${{ needs.build-matrix.result }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           # Helper function to convert result to emoji
           result_emoji() {
@@ -1126,11 +1150,11 @@ jobs:
           }
 
           # Determine overall workflow status
-          validate_result="${{ needs.validate-secrets.result }}"
-          analyze_result="${{ needs.analyze.result }}"
-          publish_result="${{ needs.publish.result }}"
-          copy_result="${{ needs.copy-to-artifacts-repo.result }}"
-          matrix_result="${{ needs.build-matrix.result }}"
+          validate_result="${RESULT_VALIDATE}"
+          analyze_result="${RESULT_ANALYZE}"
+          publish_result="${RESULT_PUBLISH}"
+          copy_result="${RESULT_COPY}"
+          matrix_result="${RESULT_MATRIX}"
 
           # Check if any job had a non-success outcome
           # (catches failure, cancelled, timed_out, etc.)
@@ -1147,11 +1171,13 @@ jobs:
           fi
 
           echo "workflow_failed=${workflow_failed}" >> "$GITHUB_OUTPUT"
-          echo "validate_result=${validate_result}" >> "$GITHUB_OUTPUT"
-          echo "analyze_result=${analyze_result}" >> "$GITHUB_OUTPUT"
-          echo "publish_result=${publish_result}" >> "$GITHUB_OUTPUT"
-          echo "copy_result=${copy_result}" >> "$GITHUB_OUTPUT"
-          echo "matrix_result=${matrix_result}" >> "$GITHUB_OUTPUT"
+          {
+            echo "validate_result=${validate_result}"
+            echo "analyze_result=${analyze_result}"
+            echo "publish_result=${publish_result}"
+            echo "copy_result=${copy_result}"
+            echo "matrix_result=${matrix_result}"
+          } >> "$GITHUB_OUTPUT"
 
           # Build a list of failed stages for the Slack message
           # (reports any non-success, non-skipped result)
@@ -1187,25 +1213,25 @@ jobs:
             echo "## 📊 Production Report Generation Complete"
             echo ""
             echo "**Completed:** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "**Status:** ${{ needs.publish.result }}"
+            echo "**Status:** ${publish_result}"
             echo ""
             echo "### Job Results"
             echo ""
             echo "- **Validate Secrets:** $(result_emoji \
-              '${{ needs.validate-secrets.result }}')"
+              "${validate_result}")"
             echo "- **Analyze:** $(result_emoji \
-              '${{ needs.analyze.result }}')"
+              "${analyze_result}")"
             echo "- **Publish:** $(result_emoji \
-              '${{ needs.publish.result }}')"
+              "${publish_result}")"
             echo "- **Copy:** $(result_emoji \
-              '${{ needs.copy-to-artifacts-repo.result }}')"
+              "${copy_result}")"
             echo ""
 
             # Note about failures - partial vs complete failure
-            if [ "${{ needs.analyze.result }}" = "failure" ]; then
+            if [ "${analyze_result}" = "failure" ]; then
               # Check if publish also failed (indicates complete failure)
-              if [ "${{ needs.publish.result }}" = "failure" ] && \
-                 [ "${{ needs.copy-to-artifacts-repo.result }}" = "failure" ]
+              if [ "${publish_result}" = "failure" ] && \
+                 [ "${copy_result}" = "failure" ]
               then
                 echo "### ❌ Complete Matrix Failure"
                 echo ""
@@ -1229,11 +1255,11 @@ jobs:
             fi
 
             # Add links to project reports if publish succeeded
-            if [ "${{ needs.publish.result }}" = "success" ]; then
+            if [ "${publish_result}" = "success" ]; then
               echo "### 📑 Project Reports"
               echo ""
-              owner="${{ github.repository_owner }}"
-              repo="${GITHUB_EVENT_REPOSITORY_NAME}"
+              owner="${REPO_OWNER}"
+              repo="${REPO_NAME}"
               base_url="https://${owner}.github.io/${repo}"
 
               # Parse and display each project with link
@@ -1260,13 +1286,15 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         # yamllint disable rule:line-length
         run: |
           # Query the GitHub API for matrix job results
           echo "Checking matrix job results..."
 
           FAILED_PROJECTS=$(gh api \
-            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+            "/repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
             --paginate \
             --jq '.jobs[] | select(.conclusion != "success" and .conclusion != null and .conclusion != "skipped" and (.name | test("^[a-z][a-z0-9-]*$"))) | .name' \
             | sort)


### PR DESCRIPTION
## Summary

Addresses all Zizmor static-analysis findings (regular **and** `--persona=auditor`) across the project workflows.

The in-place refactors preserve runtime behaviour. The one intentional behavioural change is the adoption of the canonical `release-drafter` workflow from the shared `actions-template` (see below).

## Changes

- **template-injection**: moved `${{ ... }}` expressions out of `run:` blocks into step-level `env:` vars (and `process.env` for `actions/github-script`). Values consumed **inside quoted heredocs** stay as `${{ ... }}` so GitHub templating still renders them; those blocks carry a justified `# zizmor: ignore[template-injection]`.
- **artipacked**: added `persist-credentials: false` to checkout steps that do not push. The `gh-pages` checkouts that later run `git push origin gh-pages` retain credentials with a justified `# zizmor: ignore[artipacked]`.
- **secrets-outside-env**: pinned secret-using jobs to a deployment `environment`.
- **undocumented-permissions / excessive-permissions**: documented each declared permission and set an explicit empty top-level `permissions:` default.
- **release-drafter.yaml**: replaced with the canonical version from `actions-template`. This intentionally changes runner hardening from `egress-policy: audit` to `egress-policy: block` (with an organisation-provided allow-list) and bumps the pinned `release-drafter` action. This is the org-standard workflow already deployed across other repositories.

## Validation

Verified locally clean with:

- `zizmor` (regular persona) — no findings
- `zizmor --persona=auditor` — no findings
- `yamllint -c .yamllint` — no warnings/errors
- `actionlint` — clean

All `prek` / pre-commit hooks pass.
