### PR TITLE
Fix: resolve zizmor auditor ref-version findings

### DIFF
--- a/.github/workflows/reporting-previews.yaml
+++ b/.github/workflows/reporting-previews.yaml
@@ -475,8 +475,8 @@ jobs:
         # persist-credentials must stay enabled: the later "Commit and push
         # preview" step runs `git push origin gh-pages` using these creds.
         # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0 # zizmor: ignore[artipacked]
-        with:
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with: # zizmor: ignore[artipacked]
           ref: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reporting-production.yaml
+++ b/.github/workflows/reporting-production.yaml
@@ -752,8 +752,8 @@ jobs:
         # "Commit and push changes" step relies on the persisted token
         # to run `git push origin gh-pages`.
         # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0 # zizmor: ignore[artipacked]
-        with:
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with: # zizmor: ignore[artipacked]
           ref: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Resolves the zizmor **auditor persona** findings for this repository (2
low findings: `ref-version-mismatch` in `reporting-previews.yaml` and
`reporting-production.yaml`).

## Background

Both gh-pages checkout steps intentionally persist credentials for a
later `git push origin gh-pages`, so they carry a
`# zizmor: ignore[artipacked]` suppression. That directive was appended
to the `uses:` line after the `# v7.0.0` version comment.

Under the auditor persona, zizmor parses the entire trailing comment as
a single token and can no longer read the version, raising
`ref-version-mismatch` on both workflows.

## Change

Move the `# zizmor: ignore[artipacked]` directive onto the step's `with:`
key. The `uses:` line keeps a clean `# v7.0.0` version comment, the
`artipacked` suppression still applies (credentials are deliberately
persisted), and the `ref-version-mismatch` findings clear.

## Verification

`zizmor --persona auditor .` reports no findings (11 ignored); `yamllint`
passes on both workflows.
