### PR TITLE
CI: Bump python-workflows to v0.2.0, fix timeout

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -39,9 +39,13 @@ jobs:
       contents: write       # Create the GitHub release / attach assets
       id-token: write       # OIDC for build provenance attestations
       attestations: write   # Build provenance attestations
-    # Pinned to python-workflows v0.1.1 release commit
+    # Pinned to python-workflows v0.2.0 release commit
     # yamllint disable-line rule:line-length
-    uses: lfreleng-actions/python-workflows/.github/workflows/build-test-release.yaml@4f48e1cd660f94ab9f1d4bbc15a948c1aca105ad  # v0.1.1
+    uses: lfreleng-actions/python-workflows/.github/workflows/build-test-release.yaml@097060f907512f93b3fd4c912a61283543d60b91  # v0.2.0
+    with:
+      # The pytest suite regularly takes 8-12 minutes per matrix job;
+      # the previous 12 minute default cancelled the slower jobs
+      test_timeout_minutes: 20
 
   test-pypi:
     name: 'Test PyPI Publishing'

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -30,6 +30,10 @@ jobs:
     permissions:
       contents: read  # Check out the repository to build and test.
       pull-requests: read  # Read PR metadata for status reporting.
-    # Pinned to python-workflows v0.1.0 release commit
+    # Pinned to python-workflows v0.2.0 release commit
     # yamllint disable-line rule:line-length
-    uses: lfreleng-actions/python-workflows/.github/workflows/build-test.yaml@4f48e1cd660f94ab9f1d4bbc15a948c1aca105ad  # v0.1.1
+    uses: lfreleng-actions/python-workflows/.github/workflows/build-test.yaml@097060f907512f93b3fd4c912a61283543d60b91  # v0.2.0
+    with:
+      # The pytest suite regularly takes 8-12 minutes per matrix job;
+      # the previous 12 minute default cancelled the slower jobs
+      test_timeout_minutes: 20


### PR DESCRIPTION
## Summary

The [v0.2.1 release run](https://github.com/lfreleng-actions/project-reporting-tool/actions/runs/29029180912) failed: three `Python Tests` matrix jobs (3.11, 3.12, 3.14) were cancelled with **"The job has exceeded the maximum execution time of 12m0s"**, so the release was never promoted or published to PyPI.

| Test job | pytest step duration | Result |
|---|---|---|
| 3.10 | 8m 15s | ✅ |
| 3.13 | 10m 08s | ✅ |
| 3.11 / 3.12 / 3.14 | killed at 12m | ❌ cancelled |

## Root cause

The workflows here pinned `python-workflows` **v0.1.1**, which hard-codes `timeout-minutes: 12` on the `python-tests` job with no way to override it. `python-workflows` **v0.2.0** (released today) makes the build/test/audit job timeouts configurable via `workflow_call` inputs — but keeps the 12 minute test default, so callers with slower suites must pass a larger value.

## Changes

- Bump both reusable workflow pins (`build-test-release.yaml`, `build-test.yaml`) to the v0.2.0 release commit `097060f907512f93b3fd4c912a61283543d60b91`
- Pass `test_timeout_minutes: 20` to give the pytest suite adequate headroom (the passing jobs at 8–10 min were already close to the 12 minute limit)
- Build and audit jobs complete well within their default budgets, so those inputs stay at defaults
- Correct a stale `v0.1.0` version comment in `build-test.yaml`

All new v0.2.0 inputs are optional and the `tag` output consumed by the caller-owned PyPI publish jobs is unchanged, so the bump is non-breaking.

## Validation

- `prek` (yamllint, actionlint, GitHub workflow validation, timeout check) passes on both files
- Verified `097060f...` is the commit SHA underlying the annotated `v0.2.0` tag (not the tag object SHA)

After merge, re-tagging `v0.2.1` will re-run the release.