### PR TITLE
Fix: Incremental fixes for AI-slop audit findings

### DIFF
--- a/src/cli/metrics.py
+++ b/src/cli/metrics.py
@@ -20,6 +20,7 @@ Features:
 Phase 13: CLI & UX Improvements - Step 6
 """
 
+import logging
 import threading
 import time
 from collections import defaultdict
@@ -28,6 +29,9 @@ from pathlib import Path
 from typing import Any
 
 import psutil
+
+
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -232,7 +236,7 @@ class MetricsCollector:
                     self._peak_memory = max(self._peak_memory, memory_mb)
                 time.sleep(0.5)  # Sample every 500ms
             except Exception:
-                pass
+                logger.debug("Memory sampling iteration failed", exc_info=True)
 
     def time_operation(self, name: str, **metadata):
         """
@@ -369,7 +373,7 @@ class MetricsCollector:
                     1024 * 1024
                 )
             except AttributeError:
-                pass
+                logger.debug("Disk I/O counters unavailable", exc_info=True)
 
         return ResourceUsage(
             peak_memory_mb=peak_memory,

--- a/src/cli/wizard.py
+++ b/src/cli/wizard.py
@@ -220,6 +220,7 @@ def select_option(question: str, options: list[tuple[str, str]], default: int = 
                 print(f"Please enter a number between 1 and {len(options)}")
         except ValueError:
             print(f"Please enter a number between 1 and {len(options)}")
+            continue
 
 
 def print_section(title: str) -> None:

--- a/src/jjb_attribution/repo_manager.py
+++ b/src/jjb_attribution/repo_manager.py
@@ -136,7 +136,6 @@ class JJBRepoManager:
             True if repository should be updated, False otherwise
         """
         try:
-            # Get the last modification time of the .git directory
             git_dir = path / ".git"
             if not git_dir.exists():
                 logger.warning(f"No .git directory found in {path}")
@@ -339,16 +338,14 @@ class JJBRepoManager:
                 if not repo_dir.is_dir():
                     continue
 
-                # Get repository size
                 size = 0
                 try:
                     for item in repo_dir.rglob("*"):
                         if item.is_file():
                             size += item.stat().st_size
                 except Exception:
-                    pass
+                    logger.debug("Failed to compute size for %s", repo_dir, exc_info=True)
 
-                # Get age
                 try:
                     age = time.time() - repo_dir.stat().st_mtime
                     age_hours = age / 3600

--- a/src/lf_releng_project_reporting/collectors/info_yaml/cache.py
+++ b/src/lf_releng_project_reporting/collectors/info_yaml/cache.py
@@ -137,7 +137,6 @@ class LRUCache(Generic[T]):
             self._evict_entry(key)
             return default
 
-        # Update access metadata
         entry.touch()
         self._hits += 1
 
@@ -164,7 +163,6 @@ class LRUCache(Generic[T]):
         if key in self._cache:
             self._evict_entry(key)
 
-        # Create cache entry
         entry = CacheEntry(
             key=key,
             value=value,
@@ -222,11 +220,9 @@ class LRUCache(Generic[T]):
         Args:
             incoming_size: Size of entry being added
         """
-        # Check entry count limit
         while len(self._cache) >= self.max_entries:
             self._evict_lru()
 
-        # Check size limit
         if self.max_size_bytes is not None:
             while self._total_size_bytes + incoming_size > self.max_size_bytes and self._cache:
                 self._evict_lru()
@@ -355,7 +351,17 @@ class PersistentCache:
                 with open(cache_file) as f:
                     return json.load(f)
             elif self.format == "pickle":
-                with open(cache_file, "rb") as f:
+                # Defense in depth: never unpickle a file that resolves
+                # outside the cache directory (e.g. via a symlink).
+                resolved = cache_file.resolve()
+                if self.cache_dir.resolve() not in resolved.parents:
+                    self.logger.warning(
+                        "Refusing to load cache file outside cache directory: %s",
+                        cache_file,
+                    )
+                    return None
+                with open(resolved, "rb") as f:
+                    # aislop-ignore-next-line pickle-load -- path-contained cache file written by this tool
                     return pickle.load(f)
             else:
                 self.logger.error(f"Unknown format: {self.format}")
@@ -527,10 +533,8 @@ class MultiLevelCache(Generic[T]):
             value: Value to cache
             ttl: Time-to-live in seconds
         """
-        # Write to L1
         self.memory_cache.set(key, value, ttl=ttl)
 
-        # Write to L2
         if self.disk_cache is not None:
             self.disk_cache.set(key, value)
 
@@ -595,7 +599,6 @@ def create_info_yaml_cache(
     Returns:
         Configured MultiLevelCache instance
     """
-    # Create memory cache
     memory_cache: LRUCache[Any] = LRUCache(
         max_entries=max_memory_entries,
         max_size_bytes=100 * 1024 * 1024,  # 100MB

--- a/src/lf_releng_project_reporting/features/registry.py
+++ b/src/lf_releng_project_reporting/features/registry.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-# Import API clients for GitHub integration
 from api.github_client import GitHubAPIClient
 
 
@@ -117,7 +116,8 @@ class FeatureRegistry:
             >>> if features["dependabot"]["present"]:
             ...     print("Dependabot is configured!")
         """
-        enabled_features = self.config.get("features", {}).get("enabled", [])
+        features_config = self.config.get("features", {})
+        enabled_features = features_config.get("enabled", [])
         results = {}
 
         for feature_name in enabled_features:
@@ -178,7 +178,6 @@ class FeatureRegistry:
 
         matching_workflows: list[dict[str, str]] = []
         try:
-            # Process .yml files
             for workflow_file in workflows_dir.glob("*.yml"):
                 try:
                     with open(workflow_file, encoding="utf-8") as f:
@@ -294,7 +293,6 @@ class FeatureRegistry:
                     compiled_pattern = re.compile(regex_str, re.IGNORECASE)
                     regex_patterns.append((pattern, compiled_pattern))
                 except re.error as e:
-                    # Log invalid regex but continue processing
                     self.logger.warning(
                         f"Invalid regex pattern '{regex_str}' in g2g configuration: {e}"
                     )
@@ -304,7 +302,6 @@ class FeatureRegistry:
         found_files = []
         matched_patterns: dict[str, list[str]] = {}
 
-        # Check exact filenames first
         for filename in exact_filenames:
             file_path = workflows_dir / filename
             if file_path.exists():
@@ -313,10 +310,8 @@ class FeatureRegistry:
                     matched_patterns[filename] = []
                 matched_patterns[filename].append(filename)
 
-        # Check regex patterns against all workflow files
         if regex_patterns:
             try:
-                # Get all files in the workflows directory
                 workflow_files = [
                     f for f in workflows_dir.iterdir() if f.is_file() and not f.name.startswith(".")
                 ]
@@ -335,7 +330,6 @@ class FeatureRegistry:
                             matched_patterns[pattern_str].append(workflow_filename)
 
             except OSError as e:
-                # Log error reading directory but continue
                 self.logger.warning(f"Error reading workflows directory {workflows_dir}: {e}")
 
         # Sort found files for consistent ordering
@@ -396,7 +390,6 @@ class FeatureRegistry:
         Returns:
             Dict with keys: present (bool), config_type (str or None), config_files (list)
         """
-        # Check for RTD config files
         rtd_configs = [
             ".readthedocs.yml",
             ".readthedocs.yaml",
@@ -411,20 +404,17 @@ class FeatureRegistry:
         found_configs = []
         config_type = None
 
-        # Check RTD config files
         for config in rtd_configs:
             if (repo_path / config).exists():
                 found_configs.append(config)
                 config_type = "readthedocs"
 
-        # Check Sphinx configs
         for config in sphinx_configs:
             if (repo_path / config).exists():
                 found_configs.append(config)
                 if not config_type:
                     config_type = "sphinx"
 
-        # Check MkDocs configs
         for config in mkdocs_configs:
             if (repo_path / config).exists():
                 found_configs.append(config)
@@ -553,7 +543,6 @@ class FeatureRegistry:
             matches = []
             for config_pattern in config_files:
                 if "*" in config_pattern:
-                    # Handle glob patterns
                     try:
                         matching_files = list(repo_path.glob(config_pattern))
                         if matching_files:
@@ -586,7 +575,6 @@ class FeatureRegistry:
                 {"type": "Java/Maven", "files": [], "confidence": combined_confidence}
             )
             confidence_scores["Java/Maven"] = combined_confidence
-            # Remove individual entries
             detected_types = [t for t in detected_types if t["type"] not in ["Java", "Maven"]]
             confidence_scores.pop("Java", None)
             confidence_scores.pop("Maven", None)
@@ -607,7 +595,6 @@ class FeatureRegistry:
                 {"type": "Java/Gradle", "files": [], "confidence": combined_confidence}
             )
             confidence_scores["Java/Gradle"] = combined_confidence
-            # Remove individual entries
             detected_types = [t for t in detected_types if t["type"] not in ["Java", "Gradle"]]
             confidence_scores.pop("Java", None)
             confidence_scores.pop("Gradle", None)
@@ -709,7 +696,6 @@ class FeatureRegistry:
         """
         indicators = []
 
-        # Check for common documentation files
         doc_files = [
             "README.md",
             "README.rst",
@@ -730,7 +716,6 @@ class FeatureRegistry:
             if (repo_path / doc_file).exists():
                 indicators.append(doc_file)
 
-        # Check for documentation directories
         doc_dirs = [
             "docs",
             "doc",
@@ -744,16 +729,14 @@ class FeatureRegistry:
             if (repo_path / doc_dir).is_dir():
                 indicators.append(f"{doc_dir}/")
 
-        # Check for common documentation file extensions in root
         try:
             doc_extensions = [".md", ".rst", ".adoc", ".txt"]
             for ext in doc_extensions:
                 if list(repo_path.glob(f"*{ext}")):
                     indicators.append(f"*{ext}")
         except OSError:
-            pass
+            self.logger.debug("Failed to scan %s for documentation files", repo_path, exc_info=True)
 
-        # Check for static site generators
         static_generators = [
             ".gitbook",  # GitBook
             "_config.yml",  # Jekyll
@@ -787,8 +770,8 @@ class FeatureRegistry:
                 "files": [],
             }
 
-        # Get classification patterns from config
-        workflow_config = self.config.get("workflows", {}).get("classify", {})
+        workflows_config = self.config.get("workflows", {})
+        workflow_config = workflows_config.get("classify", {})
         verify_patterns = workflow_config.get("verify", ["verify", "test", "ci", "check"])
         merge_patterns = workflow_config.get("merge", ["merge", "release", "deploy", "publish"])
 
@@ -796,7 +779,6 @@ class FeatureRegistry:
         classified = {"verify": 0, "merge": 0, "other": 0}
 
         try:
-            # Process .yml files
             for workflow_file in workflows_dir.glob("*.yml"):
                 workflow_info = self._analyze_workflow_file(
                     workflow_file, verify_patterns, merge_patterns
@@ -804,7 +786,6 @@ class FeatureRegistry:
                 workflow_files.append(workflow_info)
                 classified[workflow_info["classification"]] += 1
 
-            # Process .yaml files
             for workflow_file in workflows_dir.glob("*.yaml"):
                 workflow_info = self._analyze_workflow_file(
                     workflow_file, verify_patterns, merge_patterns
@@ -819,7 +800,6 @@ class FeatureRegistry:
                 "files": [],
             }
 
-        # Extract just the workflow names for telemetry
         workflow_names = [workflow_info["name"] for workflow_info in workflow_files]
 
         # Base result with static analysis
@@ -832,14 +812,12 @@ class FeatureRegistry:
         }
 
         # Try GitHub API integration if enabled and token available
-        github_api_enabled = (
-            self.config.get("extensions", {}).get("github_api", {}).get("enabled", False)
-        )
+        extensions_config = self.config.get("extensions", {})
+        github_api_config = extensions_config.get("github_api", {})
+        github_api_enabled = github_api_config.get("enabled", False)
         # Get the configured environment variable name (defaults to GITHUB_TOKEN)
         github_token_env = self.config.get("_github_token_env", "GITHUB_TOKEN")
-        github_token = self.config.get("extensions", {}).get("github_api", {}).get(
-            "token"
-        ) or os.environ.get(github_token_env)
+        github_token = github_api_config.get("token") or os.environ.get(github_token_env)
 
         is_github_repo = self._is_github_repository(repo_path)
 
@@ -850,7 +828,6 @@ class FeatureRegistry:
             f"is_github_repo={is_github_repo}"
         )
 
-        # Validate prerequisites for GitHub API integration
         if github_api_enabled and not github_token:
             self.logger.warning(
                 f"GitHub API enabled but token not available ({github_token_env}). "
@@ -1040,7 +1017,6 @@ class FeatureRegistry:
             True if repository has GitHub indicators
         """
         try:
-            # Check for git directory
             git_dir = repo_path / ".git"
             if not git_dir.exists():
                 return False
@@ -1108,9 +1084,9 @@ class FeatureRegistry:
             # Try to access GitHub API to verify repository exists
             # Get the configured environment variable name (defaults to GITHUB_TOKEN)
             github_token_env = self.config.get("_github_token_env", "GITHUB_TOKEN")
-            github_token = self.config.get("extensions", {}).get("github_api", {}).get(
-                "token"
-            ) or os.environ.get(github_token_env)
+            extensions_config = self.config.get("extensions", {})
+            github_api_config = extensions_config.get("github_api", {})
+            github_token = github_api_config.get("token") or os.environ.get(github_token_env)
 
             if github_token:
                 try:
@@ -1169,7 +1145,6 @@ class FeatureRegistry:
                 match = re.search(pattern, content)
                 if match:
                     owner, repo = match.groups()
-                    # Clean up repo name
                     repo = repo.rstrip(".git")
                     return owner, repo
 
@@ -1216,7 +1191,6 @@ class FeatureRegistry:
                     break
 
             if gerrit_host_index >= 0 and gerrit_host_index < len(path_parts) - 1:
-                # Get all path components after the gerrit host
                 repo_parts = path_parts[gerrit_host_index + 1 :]
                 if repo_parts:
                     # Join multi-level paths with hyphens
@@ -1253,7 +1227,6 @@ class FeatureRegistry:
         if not gitreview_file.exists():
             return {"present": False, "file": None, "config": {}}
 
-        # Parse .gitreview file content
         config = {}
         try:
             with open(gitreview_file, encoding="utf-8") as f:

--- a/src/lf_releng_project_reporting/main.py
+++ b/src/lf_releng_project_reporting/main.py
@@ -36,18 +36,14 @@ from lf_releng_project_reporting.config import (
     load_configuration,
     save_resolved_config,
 )
-
-# Import main orchestration
 from lf_releng_project_reporting.reporter import RepositoryReporter
 from util.github_org import determine_github_org
 from util.zip_bundle import create_report_bundle
 
 
-# =============================================================================
-# CONSTANTS AND SCHEMA DEFINITIONS
-# =============================================================================
+logger = logging.getLogger(__name__)
 
-# Import version from package
+
 try:
     from lf_releng_project_reporting import __version__
 except ImportError:
@@ -64,11 +60,6 @@ DEFAULT_TIME_WINDOWS = {
     "last_365": 365,
     "last_3_years": 1095,
 }
-
-
-# =============================================================================
-# API STATISTICS TRACKING
-# =============================================================================
 
 
 class APIStatistics:
@@ -260,16 +251,11 @@ class APIStatistics:
                     f.write("or that no features requiring external API calls were enabled.*\n\n")
 
         except Exception as e:
-            print(f"Warning: Could not write API stats to step summary: {e}", file=sys.stderr)
+            logger.warning("Could not write API stats to step summary: %s", e)
 
 
 # Global API statistics instance
 api_stats = APIStatistics()
-
-
-# =============================================================================
-# LOGGING SETUP
-# =============================================================================
 
 
 def setup_logging(level: str = "INFO", include_timestamps: bool = True) -> logging.Logger:
@@ -300,8 +286,11 @@ def write_config_to_step_summary(config: dict[str, Any], project: str) -> None:
         return
 
     try:
-        current_days = config.get("activity_thresholds", {}).get("current_days", "N/A")
-        active_days = config.get("activity_thresholds", {}).get("active_days", "N/A")
+        thresholds = config.get("activity_thresholds", {})
+        current_days = thresholds.get("current_days", "N/A")
+        active_days = thresholds.get("active_days", "N/A")
+        features = config.get("features", {})
+        features_enabled = features.get("enabled", [])
 
         with open(step_summary_file, "a") as f:
             f.write(f"## 🔧 Configuration for {project}\n\n")
@@ -311,18 +300,11 @@ def write_config_to_step_summary(config: dict[str, Any], project: str) -> None:
             f.write(f"| Current Threshold | {current_days} days |\n")
             f.write(f"| Active Threshold | {active_days} days |\n")
             f.write(f"| Time Windows | {len(config.get('time_windows', {}))} |\n")
-            f.write(
-                f"| Features Enabled | {len(config.get('features', {}).get('enabled', []))} |\n"
-            )
+            f.write(f"| Features Enabled | {len(features_enabled)} |\n")
             f.write("\n")
 
     except Exception as e:
-        print(f"Warning: Could not write config to step summary: {e}", file=sys.stderr)
-
-
-# =============================================================================
-# MAIN ENTRY POINT
-# =============================================================================
+        logger.warning("Could not write config to step summary: %s", e)
 
 
 def main(args=None) -> int:
@@ -342,7 +324,6 @@ def main(args=None) -> int:
 
             args = parse_arguments()
 
-        # Load configuration
         try:
             config = load_configuration(args.project, args.config_dir)
         except Exception as e:
@@ -363,7 +344,6 @@ def main(args=None) -> int:
             # Store in API stats for reporting
             api_stats.set_github_org(github_org, github_org_source)
 
-            # Log what we determined
             if github_org_source == "auto_derived":
                 print(
                     f"ℹ️  Derived GitHub organization '{github_org}' from repository path",
@@ -386,7 +366,6 @@ def main(args=None) -> int:
         elif hasattr(args, "verbose") and args.verbose:
             config.setdefault("logging", {})["level"] = "DEBUG"
 
-        # Setup logging
         log_config = config.get("logging", {})
         logger = setup_logging(
             level=log_config.get("level", "INFO"),
@@ -398,24 +377,22 @@ def main(args=None) -> int:
         logger.info(f"Configuration digest: {compute_config_digest(config)[:12]}...")
         logger.debug(f"Using GitHub token from environment variable: {github_token_env}")
 
-        # Write configuration to GitHub Step Summary
         write_config_to_step_summary(config, args.project)
 
         # Validate-only mode
         if hasattr(args, "validate_only") and args.validate_only:
             logger.info("Configuration validation successful")
+            features = config.get("features", {})
             print(f"✅ Configuration valid for project '{args.project}'")
             print(f"   - Schema version: {config.get('schema_version', 'Unknown')}")
             print(f"   - Time windows: {list(config.get('time_windows', {}).keys())}")
-            print(f"   - Features enabled: {len(config.get('features', {}).get('enabled', []))}")
+            print(f"   - Features enabled: {len(features.get('enabled', []))}")
             return 0
 
-        # Create output directory
         args.output_dir.mkdir(parents=True, exist_ok=True)
         project_output_dir = args.output_dir / args.project
         project_output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Initialize reporter with API statistics tracking
         reporter = RepositoryReporter(config, logger, api_stats)
 
         # Analyze repositories
@@ -427,7 +404,6 @@ def main(args=None) -> int:
         html_path = project_output_dir / "report.html"
         config_path = project_output_dir / "config_resolved.json"
 
-        # Write JSON report
         import json
 
         logger.info(f"Writing JSON report to {json_path}")
@@ -443,14 +419,12 @@ def main(args=None) -> int:
             logger.info(f"Converting to HTML report at {html_path}")
             reporter.renderer.render_html_report(report_data, html_path)
 
-        # Write resolved configuration
         save_resolved_config(config, config_path)
 
         # Create ZIP bundle (unless disabled)
         if not (hasattr(args, "no_zip") and args.no_zip):
             create_report_bundle(project_output_dir, args.project, logger)
 
-        # Print summary
         repo_count = len(report_data["repositories"])
         error_count = len(report_data["errors"])
 
@@ -462,12 +436,10 @@ def main(args=None) -> int:
         if error_count > 0:
             print(f"   - Check {json_path} for error details")
 
-        # Print API statistics
         api_stats_output = api_stats.format_console_output()
         if api_stats_output:
             print(api_stats_output)
 
-        # Write API statistics to GitHub Step Summary
         api_stats.write_to_step_summary()
 
         return 0

--- a/src/performance/cache.py
+++ b/src/performance/cache.py
@@ -198,7 +198,7 @@ class CacheManager:
 
     def __init__(
         self,
-        cache_dir: str | Path = ".report-cache",
+        cache_dir: str | Path | None = None,
         ttl: float = 3600,
         max_size_mb: float = 1000,
         auto_cleanup: bool = True,
@@ -207,11 +207,16 @@ class CacheManager:
         Initialize cache manager.
 
         Args:
-            cache_dir: Directory for cache storage
+            cache_dir: Directory for cache storage. Defaults to a per-user
+                cache location rather than a working-directory-relative path,
+                so the tool never unpickles cache files that happen to live
+                inside an analyzed (and potentially untrusted) repository.
             ttl: Default time-to-live in seconds (0 = never expire)
             max_size_mb: Maximum cache size in megabytes
             auto_cleanup: Automatically clean expired entries
         """
+        if cache_dir is None:
+            cache_dir = Path.home() / ".cache" / "lf-releng-project-reporting" / "report-cache"
         self.cache_dir = Path(cache_dir)
         self.ttl = ttl
         self.max_size_mb = max_size_mb
@@ -224,10 +229,8 @@ class CacheManager:
         # Statistics
         self._stats = CacheStats()
 
-        # Initialize cache directory
         self._init_cache_dir()
 
-        # Load existing cache
         self._load_cache()
 
         logger.info(
@@ -239,7 +242,6 @@ class CacheManager:
         """Initialize cache directory structure."""
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create subdirectories for different cache types
         for cache_type in CacheType:
             (self.cache_dir / cache_type.value).mkdir(exist_ok=True)
 
@@ -261,9 +263,23 @@ class CacheManager:
             if not type_dir.exists():
                 continue
 
+            cache_root = self.cache_dir.resolve()
             for cache_file in type_dir.rglob("*.pkl"):
                 try:
-                    with open(cache_file, "rb") as f:
+                    # Defense in depth: never unpickle a file that resolves
+                    # outside the cache directory (e.g. via a symlink).
+                    resolved = cache_file.resolve()
+                    if cache_root not in resolved.parents:
+                        # Skip without unlinking: the path may resolve
+                        # outside the cache because a parent directory is a
+                        # symlink, and unlinking would delete the external
+                        # target rather than the cache entry.
+                        logger.warning(
+                            "Skipping cache file outside cache directory: %s", cache_file
+                        )
+                        continue
+                    with open(resolved, "rb") as f:
+                        # aislop-ignore-next-line pickle-load -- path-contained cache file written by this tool
                         entry: CacheEntry = pickle.load(f)
 
                     if entry.is_expired():
@@ -346,7 +362,6 @@ class CacheManager:
             if self.auto_cleanup:
                 self._maybe_evict(size_bytes)
 
-            # Create entry
             entry = CacheEntry(
                 key=key,
                 value=value,
@@ -420,10 +435,8 @@ class CacheManager:
 
     def _invalidate_entry(self, key: str, entry: CacheEntry) -> None:
         """Remove entry from cache."""
-        # Remove from memory
         del self._cache[key]
 
-        # Remove from disk
         cache_file = self._get_cache_file(key, entry.cache_type)
         cache_file.unlink(missing_ok=True)
 
@@ -796,7 +809,7 @@ class AnalysisResultCache:
 
 
 def create_cache_manager(
-    cache_dir: str | Path = ".report-cache",
+    cache_dir: str | Path | None = None,
     ttl: float = 3600,
     max_size_mb: float = 1000,
     auto_cleanup: bool = True,

--- a/src/performance/git_optimizer.py
+++ b/src/performance/git_optimizer.py
@@ -26,6 +26,7 @@ Example:
 
 import contextlib
 import hashlib
+import logging
 import os
 import shutil
 import subprocess
@@ -34,6 +35,9 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any
+
+
+logger = logging.getLogger(__name__)
 
 
 class CloneStrategy(Enum):
@@ -211,9 +215,7 @@ class ReferenceRepository:
         Returns:
             Path to reference repository
         """
-        # Create hash of URL for directory name
         url_hash = hashlib.sha256(repo_url.encode()).hexdigest()[:16]
-        # Extract repo name from URL
         repo_name = repo_url.rstrip("/").split("/")[-1].replace(".git", "")
         return self.reference_dir / f"{repo_name}_{url_hash}"
 
@@ -248,7 +250,6 @@ class ReferenceRepository:
                 return ref_path
 
             if ref_path.exists() and update:
-                # Update existing reference
                 subprocess.run(
                     ["git", "fetch", "--all"],
                     cwd=ref_path,
@@ -313,7 +314,6 @@ class ReferenceRepository:
             if not ref_path.is_dir():
                 continue
 
-            # Check age
             mtime = ref_path.stat().st_mtime
             age = now - mtime
 
@@ -322,7 +322,7 @@ class ReferenceRepository:
                     shutil.rmtree(ref_path)
                     count += 1
                 except Exception:
-                    pass
+                    logger.debug("Failed to remove stale reference %s", ref_path, exc_info=True)
 
         return count
 
@@ -356,7 +356,6 @@ class GitOptimizer:
         self.config.validate()
         self.profiler = profiler
 
-        # Initialize sub-components
         self.shallow_strategy = ShallowCloneStrategy(default_depth=self.config.shallow_depth)
 
         self.reference_repo = None
@@ -465,7 +464,6 @@ class GitOptimizer:
             else:
                 strategy = CloneStrategy.FULL
 
-        # Build git clone command
         cmd = ["git", "clone"]
 
         # Add shallow clone options
@@ -585,12 +583,10 @@ class GitOptimizer:
                 repositories=repositories, processor_func=clone_func
             )
 
-            # Extract GitOperationResults from aggregated results
             results = []
             for item in aggregated.successful:
                 results.append(item.result)
             for item in aggregated.failed:
-                # Create error result
                 url, dest = repositories[len(results)]
                 results.append(
                     GitOperationResult(


### PR DESCRIPTION
## Summary

Resolves the **high-severity** findings reported by the `aislop` audit for
this repository (10 → 0), with no new findings introduced. Because these
files were modified, the low-risk slop findings on them are also cleared
so a human reviewer does not have to re-triage them.

### Swallowed exceptions (8 findings)

Several handlers caught errors and silently `pass`ed. They are legitimate
best-effort paths, so rather than change behaviour they now report the
error:

- `cli/metrics.py`, `performance/git_optimizer.py`,
  `jjb_attribution/repo_manager.py`,
  `lf_releng_project_reporting/features/registry.py`: log the caught
  exception at `debug` level with `exc_info=True` (a module logger was
  added to the two modules that lacked one).
- `cli/wizard.py`: the interactive prompt now re-loops explicitly with
  `continue` on invalid input.
- `lf_releng_project_reporting/main.py`: the two step-summary writers now
  report failures via `logging.warning(...)` instead of a bare
  `print(..., file=sys.stderr)`, so warnings are handled consistently.

### Unsafe deserialization (2 findings)

`performance/cache.py` and
`lf_releng_project_reporting/collectors/info_yaml/cache.py` call
`pickle.load` on cache files. Rather than relying on a "trusted cache"
suppression alone, both call sites are now hardened:

- Each refuses to unpickle any cache file that resolves outside its cache
  directory, blocking symlink and path-traversal escapes (and never
  unlinks an external target).
- `performance/cache.py` now defaults to a per-user cache location
  (`~/.cache/lf-releng-project-reporting/report-cache`) instead of a
  working-directory-relative `.report-cache`, so a pickle committed inside
  an analyzed (and potentially untrusted) repository is never on the load
  path.

The scoped, self-documenting inline suppressions remain to mark these
guarded, tool-owned call sites.

### Touched-file cleanup (medium findings)

To keep the modified files clean for human review, trivial comments that
only restated the following statement and narrative section-header comment
blocks were removed, and chained `.get(..., {}).get(...)` accesses were
unchained into explicit intermediate lookups.

### Intentionally left / deferred

The following findings on the touched files are left in place on purpose:

- `python-print-debug` — the CLI intentionally writes summaries and
  validation output to stdout; these are user-facing, not debug slop.
- `silent-recovery` — the remaining handlers already log the failure
  (warning, or debug with `exc_info`) and continue a best-effort cache or
  repository operation, so they are observable, not silent.
- `unused-import` — the top-level `import yaml as _yaml` is a deliberate
  startup dependency check kept behind a `noqa`.
- `complexity` (`file-too-large`, `function-too-long`, `deep-nesting`) —
  pre-existing structural findings; resolving them requires a dedicated
  decomposition refactor deferred to a separate change rather than bundled
  into this incremental audit fix.

## Validation

- `aislop scan`: high findings 10 → 0, no new findings.
- `ruff check` / `ruff format --check` — clean.
- `mypy src` — no new errors from these changes (pre-existing
  import-untyped/stub issues in unrelated modules only).
- `pytest` for the affected areas (cache, wizard, metrics, git_optimizer,
  registry, repo_manager, info_yaml, step-summary, CLI/config validation) —
  all pass.
