### PR TITLE
Chore: Drop Python 3.10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ reports/
 
 ## 🔧 Requirements
 
-- **Python**: 3.10+ (supports 3.10, 3.11, 3.12, 3.13)
+- **Python**: 3.11+ (supports 3.11, 3.12, 3.13, 3.14)
 - **Dependencies**: PyYAML, httpx, Jinja2, typer, rich
 - **Optional**: GitHub token for API features (required for workflow status colors)
 

--- a/docs/CI_CD_INTEGRATION.md
+++ b/docs/CI_CD_INTEGRATION.md
@@ -123,7 +123,7 @@ What It Validates:
 
 Jobs:
 
-- `smoke-tests`: Quick validation (Python 3.10, 3.11, 3.12)
+- `smoke-tests`: Quick validation (Python 3.11, 3.12, 3.13, 3.14)
 - `unit-tests`: Full unit test suite with coverage
 - `integration-tests`: Component integration tests
 - `property-tests`: Property-based tests (Hypothesis)
@@ -137,7 +137,7 @@ Test Matrix:
 ```yaml
 strategy:
   matrix:
-    python-version: ['3.10', '3.11', '3.12']
+    python-version: ['3.11', '3.12', '3.13', '3.14']
     os: [ubuntu-latest, macos-latest, windows-latest]
 ```
 
@@ -864,7 +864,7 @@ Python Version Updates:
 
 ```yaml
 # Add new Python version to matrix
-python-version: ['3.10', '3.11', '3.12', '3.13']
+python-version: ['3.11', '3.12', '3.13', '3.14']
 ```
 
 ---

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -91,11 +91,11 @@ Hardware Requirements:
 
 Software Requirements:
 
-- [ ] **Python:** 3.10, 3.11, or 3.12 installed
+- [ ] **Python:** 3.11, 3.12, 3.13, or 3.14 installed
 
   ```bash
   python --version
-  # Expected: Python 3.10.x, 3.11.x, or 3.12.x
+  # Expected: Python 3.11.x, 3.12.x, 3.13.x, or 3.14.x
   ```
 
 - [ ] **pip:** Latest version

--- a/docs/FEATURE_DISCOVERY_GUIDE.md
+++ b/docs/FEATURE_DISCOVERY_GUIDE.md
@@ -217,7 +217,7 @@ Feature: docker
 
 📋 Configuration Example:
 
-  FROM python:3.10-slim
+  FROM python:3.11-slim
   WORKDIR /app
   COPY requirements.txt .
   RUN uv sync  # Recommended

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -13,7 +13,7 @@ SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 Before you begin, ensure you have:
 
-- **Python 3.10+** (supports 3.10, 3.11, 3.12, 3.13)
+- **Python 3.11+** (supports 3.11, 3.12, 3.13, 3.14)
 - **Git** installed
 - **Repositories** cloned locally (the repos you want to analyze)
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -95,7 +95,7 @@ The modern reporting system provides:
 
 | Component            | Legacy                | Modern                 | Compatible |
 | -------------------- | --------------------- | ---------------------- | ---------- |
-| **Python**           | 3.10+                 | 3.10+                  | ✅ Yes     |
+| **Python**           | 3.10+                 | 3.11+                  | ✅ Yes     |
 | **Configuration**    | YAML                  | YAML                   | ✅ Yes     |
 | **Data Format**      | JSON                  | JSON                   | ✅ Yes     |
 | **APIs**             | Gerrit/GitHub/Jenkins | Gerrit/GitHub/Jenkins  | ✅ Yes     |
@@ -128,7 +128,7 @@ cp -r reports/ reports.backup/
 
 ```bash
 # Check Python version
-python --version  # Should be 3.10+
+python --version  # Should be 3.11+
 
 # Check required tools
 which git

--- a/docs/TESTING_GITHUB_NATIVE.md
+++ b/docs/TESTING_GITHUB_NATIVE.md
@@ -19,7 +19,7 @@ SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 ```bash
 # Python environment
-python --version  # 3.10+
+python --version  # 3.11+
 uv --version      # Latest
 
 # GitHub CLI (required for GitHub project cloning)

--- a/docs/guides/TEMPLATE_DEVELOPMENT.md
+++ b/docs/guides/TEMPLATE_DEVELOPMENT.md
@@ -55,7 +55,7 @@ This guide covers template development for the Repository Reporting System's mod
 
 ```bash
 # Required
-Python 3.10+
+Python 3.11+
 Jinja2 3.0+
 
 # Optional (for development)

--- a/docs/testing/PARALLEL_EXECUTION.md
+++ b/docs/testing/PARALLEL_EXECUTION.md
@@ -479,7 +479,7 @@ Solutions:
 ```yaml
 strategy:
   matrix:
-    python-version: ['3.10', '3.11', '3.12']
+    python-version: ['3.11', '3.12', '3.13', '3.14']
     os: [ubuntu-latest, macos-latest, windows-latest]
 
 steps:

--- a/docs/testing/TEST_PREREQUISITES.md
+++ b/docs/testing/TEST_PREREQUISITES.md
@@ -30,7 +30,7 @@ SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 ```bash
 # Check your versions
-python --version    # Need: 3.10+
+python --version    # Need: 3.11+
 git --version       # Need: 2.25+
 pytest --version    # Need: 7.0+
 
@@ -93,7 +93,7 @@ Notes:
 
 ### Required Software
 
-#### Python 3.10+
+#### Python 3.11+
 
 **Why:** Core language for the project
 
@@ -107,8 +107,8 @@ python3 --version
 
 Install:
 
-- **Ubuntu/Debian:** `sudo apt-get install python3.10 python3.10-dev`
-- **macOS:** `brew install python@3.10`
+- **Ubuntu/Debian:** `sudo apt-get install python3.11 python3.11-dev`
+- **macOS:** `brew install python@3.11`
 - **Windows:** Download from [python.org](https://www.python.org/downloads/)
 
 #### Git 2.25+
@@ -425,7 +425,7 @@ load_dotenv()
 
 ### Before Running Tests
 
-- [ ] Python 3.10+ installed
+- [ ] Python 3.11+ installed
 - [ ] Git 2.25+ installed
 - [ ] Virtual environment activated
 - [ ] Dependencies installed (`pip install -r requirements-dev.txt`)
@@ -685,7 +685,7 @@ echo "=== ✅ Environment validation complete ==="
 ### Minimum Setup (5 minutes)
 
 ```bash
-# 1. Install Python 3.10+ and Git 2.25+
+# 1. Install Python 3.11+ and Git 2.25+
 # 2. Create virtual environment
 python3 -m venv venv
 source venv/bin/activate

--- a/examples/README.md
+++ b/examples/README.md
@@ -110,7 +110,7 @@ When adding new examples:
 
 All examples require:
 
-- Python 3.10+
+- Python 3.11+
 - Repository reporting system source code
 - Dependencies from project root
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -47,7 +46,7 @@ keywords = [
     "linux-foundation",
     "committers",
 ]
-requires-python = ">=3.10.2"
+requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.28.1",
     "PyYAML>=6.0.3",
@@ -240,7 +239,7 @@ directory = "htmlcov"
 
 # MyPy configuration
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
@@ -274,7 +273,7 @@ ignore_missing_imports = true
 
 # Basedpyright / Pyright configuration
 [tool.basedpyright]
-pythonVersion = "3.10"
+pythonVersion = "3.11"
 include = ["src"]
 # Use standard (stock pyright) checking mode rather than the stricter
 # basedpyright-specific defaults. The codebase uses mypy (see
@@ -292,7 +291,7 @@ reportMissingModuleSource = "none"
 # Ruff configuration
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 src = ["src"]
 extend-exclude = [
     ".git",
@@ -341,7 +340,7 @@ lines-after-imports = 2
 # Black configuration (if needed as fallback)
 [tool.black]
 line-length = 100
-target-version = ["py310", "py311", "py312", "py313"]
+target-version = ["py311", "py312", "py313"]
 include = '\.pyi?$'
 extend-exclude = '''
 /(

--- a/src/lf_releng_project_reporting/collectors/git.py
+++ b/src/lf_releng_project_reporting/collectors/git.py
@@ -1114,7 +1114,7 @@ class GitDataCollector:
                 try:
                     commit_date = parse_git_iso_date(parts[1])
                     if commit_date.tzinfo is None:
-                        commit_date = commit_date.replace(tzinfo=datetime.timezone.utc)
+                        commit_date = commit_date.replace(tzinfo=datetime.UTC)
                 except (ValueError, IndexError) as e:
                     self.logger.warning(
                         f"Invalid date format in {repo_name}: {parts[1] if len(parts) > 1 else 'unknown'} - {e}"
@@ -1236,12 +1236,12 @@ class GitDataCollector:
                 try:
                     last_commit_date = parse_git_iso_date(output.strip())
                     if last_commit_date.tzinfo is None:
-                        last_commit_date = last_commit_date.replace(tzinfo=datetime.timezone.utc)
+                        last_commit_date = last_commit_date.replace(tzinfo=datetime.UTC)
 
                     repo_metrics["last_commit_timestamp"] = last_commit_date.isoformat()
 
                     # Calculate days since last commit
-                    now = datetime.datetime.now(datetime.timezone.utc)
+                    now = datetime.datetime.now(datetime.UTC)
                     days_since = (now - last_commit_date).days
                     repo_metrics["days_since_last_commit"] = days_since
 

--- a/src/lf_releng_project_reporting/reporter.py
+++ b/src/lf_releng_project_reporting/reporter.py
@@ -158,7 +158,7 @@ class RepositoryReporter:
         # Pass schema_version and script_version from constants in main module
         report_data = {
             "schema_version": self.config.get("_schema_version", "1.0.0"),
-            "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "generated_at": datetime.datetime.now(datetime.UTC).isoformat(),
             "project": self.config["project"],
             "config_digest": self._compute_config_digest(self.config),
             "script_version": self.config.get("_script_version", "1.0.0"),
@@ -579,7 +579,7 @@ class RepositoryReporter:
         """
         from datetime import timedelta
 
-        now = datetime.datetime.now(datetime.timezone.utc)
+        now = datetime.datetime.now(datetime.UTC)
         windows = {}
 
         # Default time windows if not specified

--- a/tests/regression/test_known_issues.py
+++ b/tests/regression/test_known_issues.py
@@ -19,7 +19,7 @@ Test Categories:
 """
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -249,7 +249,7 @@ class TestEdgeCaseRegressions:
 
         # Should parse without overflow
         dt = datetime.fromisoformat(old_timestamp.replace("Z", "+00:00"))
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         days_since = (now - dt).days
 

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -11,7 +11,7 @@ This module tests the template-based rendering system including:
 - Template output correctness
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -67,7 +67,7 @@ class TestFormatters:
 
     def test_format_date_datetime(self):
         """Test date formatting with datetime object."""
-        dt = datetime(2025, 1, 16, 14, 30, 0, tzinfo=timezone.utc)
+        dt = datetime(2025, 1, 16, 14, 30, 0, tzinfo=UTC)
         assert format_date(dt) == "2025-01-16"
 
     def test_format_date_string(self):
@@ -77,7 +77,7 @@ class TestFormatters:
 
     def test_format_date_custom_format(self):
         """Test date formatting with custom format string."""
-        dt = datetime(2025, 1, 16, 14, 30, 0, tzinfo=timezone.utc)
+        dt = datetime(2025, 1, 16, 14, 30, 0, tzinfo=UTC)
         assert format_date(dt, format_str="%Y/%m/%d") == "2025/01/16"
         assert format_date(dt, format_str="%B %d, %Y") == "January 16, 2025"
 

--- a/tests/unit/test_rendering_formatters.py
+++ b/tests/unit/test_rendering_formatters.py
@@ -16,7 +16,6 @@ Phase: 12, Step 4, Task 1.3
 """
 
 import datetime
-from datetime import timezone
 
 from rendering.formatters import (
     UNKNOWN_AGE,
@@ -339,7 +338,7 @@ class TestFormatDate:
 
     def test_format_date_with_timezone_object(self):
         """Test datetime with timezone."""
-        dt = datetime.datetime(2025, 1, 16, 14, 30, 0, tzinfo=timezone.utc)
+        dt = datetime.datetime(2025, 1, 16, 14, 30, 0, tzinfo=datetime.UTC)
         assert format_date(dt) == "2025-01-16"
 
 


### PR DESCRIPTION
## Summary

Python 3.10 reaches end of life at the end of October 2026 (roughly three
months away), and continuing to support it has begun to surface test and lint
failures. This change removes 3.10 from the supported version set so the
project baseline becomes **3.11**.

## Changes

- **`pyproject.toml`**
  - Raise `requires-python` from `>=3.10.2` to `>=3.11`
  - Drop the `Programming Language :: Python :: 3.10` trove classifier
  - Retarget `mypy` (`python_version`), `basedpyright` (`pythonVersion`),
    `ruff` (`target-version = "py311"`) and `black` (drop `py310`)
- **Source/tests** — retargeting ruff at `py311` surfaces the `UP017`
  pyupgrade rule, which prefers the `datetime.UTC` alias (added in 3.11) over
  `datetime.timezone.utc`. Applied that rewrite across the affected `src/` and
  `tests/` modules.
- **Docs** — updated the Python version references throughout the README and
  `docs/` to reflect the 3.11+ baseline.

## CI matrix

The Python test/audit matrix is derived from `requires-python` by the
`lfreleng-actions/python-workflows` reusable pipeline (via
`python-build-action`), so the matrix drops 3.10 automatically — no workflow
edit is required.

## Validation

- `ruff check` / `ruff format` — clean (verified against the pinned
  `ruff-pre-commit` v0.15.22 via `prek`)
- `prek run` across all changed files — all hooks pass (ruff, ruff-format,
  mypy, basedpyright, reuse, markdownlint, codespell)
- `pytest` on the affected modules under Python 3.11 — all green

## Context

Raised as a standalone change ahead of the in-flight AI-slop remediation work
(#245), which will be rebased on top once this merges.