### PR TITLE
Fix: Sync .python-version with requires-python

### DIFF
--- a/.github/workflows/performance-tracking.yaml
+++ b/.github/workflows/performance-tracking.yaml
@@ -50,11 +50,13 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
 
-      - name: Set up Python 3.11
+      - name: Set up Python
         # yamllint disable-line rule:line-length
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: '3.11'
+          # Single source of truth: read the interpreter from
+          # .python-version so setup-python and `uv sync` never disagree.
+          python-version-file: '.python-version'
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -291,11 +293,13 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
 
-      - name: Set up Python 3.11
+      - name: Set up Python
         # yamllint disable-line rule:line-length
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: '3.11'
+          # Single source of truth: read the interpreter from
+          # .python-version so setup-python and `uv sync` never disagree.
+          python-version-file: '.python-version'
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/reporting-previews.yaml
+++ b/.github/workflows/reporting-previews.yaml
@@ -287,7 +287,9 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: "3.11"
+          # Single source of truth: read the interpreter from
+          # .python-version so setup-python and `uv sync` never disagree.
+          python-version-file: ".python-version"
 
       - name: "Install dependencies"
         shell: bash

--- a/.github/workflows/reporting-production.yaml
+++ b/.github/workflows/reporting-production.yaml
@@ -445,7 +445,9 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: "3.11"
+          # Single source of truth: read the interpreter from
+          # .python-version so setup-python and `uv sync` never disagree.
+          python-version-file: ".python-version"
 
       - name: "Install dependencies"
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -144,3 +144,13 @@ repos:
         language: script
         files: ^testing/projects\.json$
         pass_filenames: true
+
+      # Keep .python-version in sync with pyproject.toml so `uv sync`
+      # never resolves an interpreter that violates requires-python.
+      - id: check-python-version
+        name: Check .python-version matches pyproject.toml
+        entry: python scripts/check-python-version.py
+        language: python
+        additional_dependencies: ["packaging"]
+        pass_filenames: false
+        files: ^(\.python-version|pyproject\.toml)$

--- a/.python-version
+++ b/.python-version
@@ -1,4 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
+#
+# Default Python interpreter for local development, `uv`, and CI.
+#
+# Keep this as the LATEST version listed in the supported set (the
+# `Programming Language :: Python :: 3.x` trove classifiers and the
+# `requires-python` floor in pyproject.toml). The value here MUST
+# satisfy `requires-python`, or `uv sync` fails to resolve an
+# interpreter. The scripts/check-python-version.py pre-commit hook
+# enforces this invariant so the two files cannot drift apart again.
 
-3.10
+3.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ keywords = [
     "linux-foundation",
     "committers",
 ]
+# Minimum supported interpreter. When bumping this floor (or the trove
+# classifiers above), also update `.python-version` to the latest
+# supported release. The scripts/check-python-version.py pre-commit
+# hook fails if `.python-version` no longer satisfies this constraint.
 requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.28.1",

--- a/scripts/check-python-version.py
+++ b/scripts/check-python-version.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+"""Validate that `.python-version` stays consistent with pyproject.toml.
+
+This guard exists because `.python-version` (the default interpreter for
+local development, ``uv``, and CI) is a hand-maintained pin that is easy
+to forget when the supported Python range changes in ``pyproject.toml``.
+A drift here is exactly what broke the scheduled production reporting run:
+``requires-python`` was raised to ``>=3.11`` while ``.python-version``
+still pinned ``3.10``, so ``uv sync`` refused to resolve an interpreter.
+
+The hook enforces two invariants:
+
+1. The version in ``.python-version`` MUST satisfy the ``requires-python``
+   constraint declared in ``pyproject.toml`` (prevents the breakage).
+2. The version in ``.python-version`` MUST be the LATEST version declared
+   in the ``Programming Language :: Python :: 3.x`` trove classifiers, so
+   the project runs against its newest supported interpreter by default.
+
+Run manually with::
+
+    python scripts/check-python-version.py
+
+It also runs automatically via pre-commit whenever ``.python-version`` or
+``pyproject.toml`` changes.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+from typing import NoReturn
+
+
+try:
+    from packaging.specifiers import InvalidSpecifier, SpecifierSet
+    from packaging.version import InvalidVersion, Version
+except ModuleNotFoundError:
+    # Emit an actionable message rather than a bare traceback when the
+    # optional dependency is missing (e.g. when run outside pre-commit).
+    sys.stderr.write(
+        "::error::The 'packaging' package is required to run "
+        "check-python-version.py. Install it (for example "
+        "`uv pip install packaging`) or run the check through pre-commit, "
+        "which provisions it automatically.\n"
+    )
+    raise SystemExit(1) from None
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PYTHON_VERSION_FILE = REPO_ROOT / ".python-version"
+
+CLASSIFIER_PREFIX = "Programming Language :: Python :: "
+
+
+def _fail(message: str) -> NoReturn:
+    """Print a GitHub-Actions-friendly error and exit non-zero."""
+    print(f"::error::{message}")
+    sys.exit(1)
+
+
+def read_pinned_version() -> str:
+    """Return the interpreter version pinned in ``.python-version``.
+
+    Comment lines (SPDX headers, explanatory notes) and blank lines are
+    ignored so the file can carry documentation alongside the pin.
+    """
+    for raw_line in PYTHON_VERSION_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line and not line.startswith("#"):
+            return line
+    _fail(f"No version pin found in {PYTHON_VERSION_FILE.name}")
+
+
+def latest_supported_version(classifiers: list[str]) -> Version | None:
+    """Return the highest ``3.x`` version from the trove classifiers."""
+    versions: list[Version] = []
+    for classifier in classifiers:
+        if not classifier.startswith(CLASSIFIER_PREFIX):
+            continue
+        suffix = classifier[len(CLASSIFIER_PREFIX) :].strip()
+        # Skip the bare "3" classifier and any non-numeric entries.
+        if "." not in suffix:
+            continue
+        try:
+            versions.append(Version(suffix))
+        except ValueError:
+            continue
+    return max(versions) if versions else None
+
+
+def main() -> int:
+    """Validate the pin and report the first mismatch found."""
+    with PYPROJECT.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+
+    project = pyproject.get("project", {})
+    requires_python = project.get("requires-python")
+    classifiers = project.get("classifiers", [])
+
+    pinned_raw = read_pinned_version()
+    try:
+        pinned = Version(pinned_raw)
+    except InvalidVersion:
+        _fail(f".python-version pins {pinned_raw!r}, which is not a valid Python version.")
+
+    if requires_python:
+        try:
+            specifier = SpecifierSet(requires_python)
+        except InvalidSpecifier:
+            _fail(
+                f"requires-python {requires_python!r} in pyproject.toml is "
+                f"not a valid version specifier."
+            )
+        if not specifier.contains(pinned, prereleases=True):
+            _fail(
+                f".python-version pins {pinned_raw!r}, which does not satisfy "
+                f"requires-python {requires_python!r} in pyproject.toml. "
+                f"Update .python-version to a compatible release."
+            )
+
+    latest = latest_supported_version(classifiers)
+    if latest is not None and pinned != latest:
+        _fail(
+            f".python-version pins {pinned_raw!r}, but the latest supported "
+            f"release declared in the pyproject.toml classifiers is "
+            f"{latest}. Pin the latest supported version so the project runs "
+            f"against its newest interpreter by default (or drop the unused "
+            f"classifier)."
+        )
+
+    print(
+        f"✅ .python-version ({pinned_raw}) satisfies requires-python "
+        f"({requires_python}) and matches the latest supported classifier."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The scheduled **Production Reports** run failed at the *Project Analysis*
and *Pages Publishing* stages
([run 29989216586](https://github.com/lfreleng-actions/project-reporting-tool/actions/runs/29989216586))
with:

```
error: The Python request from `.python-version` resolved to Python 3.10.20,
which is incompatible with the project's Python requirement: `>=3.11`
```

### Root cause

Commit `551735d` ("Chore: Drop Python 3.10 support") raised
`requires-python` to `>=3.11` and retargeted the tooling, but left
`.python-version` still pinned to `3.10`. In every reporting/perf job the
pattern is `install uv → setup-python → uv sync`, and `uv sync` reads
`.python-version` (3.10), which no longer satisfies the `>=3.11` floor.
`analyze` failed for all projects, and `publish` failed because it
depends on the analyze artifacts.

## Changes

- **Fix the pin:** `.python-version` → `3.14`, the latest supported
  release (per the trove classifiers), so the tool runs against its
  newest interpreter by default rather than the oldest.
- **Remove the drift surface:** point `setup-python` at
  `python-version-file: .python-version` in `reporting-production.yaml`,
  `reporting-previews.yaml`, and `performance-tracking.yaml` (x2) so
  `setup-python` and `uv` share a single source of truth. Both readers
  ignore the SPDX/comment header lines in `.python-version`.
- **Prevent recurrence:** add `scripts/check-python-version.py` and a
  `check-python-version` pre-commit hook that fails when
  `.python-version` no longer satisfies `requires-python`, or is not the
  latest declared classifier (enforcing the "run latest by default"
  policy).
- **Label the invariant:** cross-referencing comments in both
  `.python-version` and `pyproject.toml`.

## Validation

- `scripts/check-python-version.py` passes (3.14 satisfies `>=3.11` and
  matches the latest classifier); `uv sync` resolves 3.14 cleanly.
- Full `pre-commit run` against all changed files passes (yamllint,
  actionlint, check-github-workflows, ruff, reuse, and the new hook).

Co-Authored-By: Claude &lt;noreply@anthropic.com&gt;