### PR TITLE
Fix: fail fast when clone yields no repositories

### DIFF
--- a/.github/workflows/reporting-previews.yaml
+++ b/.github/workflows/reporting-previews.yaml
@@ -258,9 +258,15 @@ jobs:
           # transient discovery/clone failure; fail here so the preview job
           # can be re-run instead of rendering an empty report.
           count_local_repos() {
+            # Mirror the report tool's discovery: it finds repositories via
+            # any ".git" entry (a directory for normal clones, or a file for
+            # worktree/submodule-style checkouts), so match by name rather
+            # than restricting to directories. Prune matched ".git" entries
+            # so find does not descend into their object/refs stores.
             path="$1"
             if [ -d "$path" ]; then
-              find "$path" -type d -name '.git' 2>/dev/null | wc -l | tr -d ' '
+              find "$path" -name '.git' -prune -print 2>/dev/null \
+                | wc -l | tr -d ' '
             else
               echo 0
             fi

--- a/.github/workflows/reporting-previews.yaml
+++ b/.github/workflows/reporting-previews.yaml
@@ -247,27 +247,55 @@ jobs:
         env:
           MATRIX_GERRIT: ${{ matrix.gerrit }}
           MATRIX_GITHUB: ${{ matrix.github }}
+          MATRIX_PROJECT: ${{ matrix.project }}
+          GERRIT_OUTCOME: ${{ steps.clone-gerrit.outcome }}
+          GITHUB_OUTCOME: ${{ steps.clone-github.outcome }}
+        # yamllint disable rule:line-length
         run: |
-          # Determine which clone step ran and check its outcome
+          # Determine which clone step ran, record the repos path for later
+          # steps, and fail fast when the clone produced no repositories. A
+          # "success" outcome with zero repositories on disk indicates a
+          # transient discovery/clone failure; fail here so the preview job
+          # can be re-run instead of rendering an empty report.
+          count_local_repos() {
+            path="$1"
+            if [ -d "$path" ]; then
+              find "$path" -type d -name '.git' 2>/dev/null | wc -l | tr -d ' '
+            else
+              echo 0
+            fi
+          }
+
           if [ -n "${MATRIX_GERRIT}" ]; then
             # Gerrit project
             clone_path="./${MATRIX_GERRIT}"
             echo "REPOS_PATH=$clone_path" >> "$GITHUB_ENV"
+            clone_outcome="${GERRIT_OUTCOME}"
           elif [ -n "${MATRIX_GITHUB}" ]; then
             # GitHub-only project
             clone_path="./github.com/${MATRIX_GITHUB}"
             echo "REPOS_PATH=$clone_path" >> "$GITHUB_ENV"
+            clone_outcome="${GITHUB_OUTCOME}"
           else
             echo "::error::No repository source configured"
             exit 1
           fi
 
-          if [ -d "$clone_path" ]; then
-            repo_count=$(find "$clone_path" -maxdepth 1 -type d | wc -l)
-            echo "✅ Clone path exists: $clone_path ($repo_count items)"
-          else
-            echo "::warning::Clone path does not exist: $clone_path"
+          if [ -n "$clone_outcome" ] && [ "$clone_outcome" != "success" ]; then
+            echo "::error::Failed to clone repositories for ${MATRIX_PROJECT} (outcome: $clone_outcome)"
+            echo "::error::Source may be unavailable or under heavy load; re-run this job to retry"
+            exit 1
           fi
+
+          on_disk="$(count_local_repos "$clone_path")"
+          echo "ℹ️ Clone path: $clone_path (${on_disk} repositories on disk)"
+          if [ "${on_disk:-0}" -eq 0 ]; then
+            echo "::error::Clone produced 0 repositories for ${MATRIX_PROJECT}"
+            echo "::error::This usually indicates a transient discovery/clone failure; re-run this job to retry."
+            exit 1
+          fi
+          echo "✅ Clone produced ${on_disk} repositories"
+        # yamllint enable rule:line-length
 
       - name: "Clone info-master repository"
         shell: bash

--- a/.github/workflows/reporting-production.yaml
+++ b/.github/workflows/reporting-production.yaml
@@ -462,10 +462,15 @@ jobs:
           count_local_repos() {
             # Count git repositories present on disk under the given path.
             # This mirrors what the report tool consumes: it discovers
-            # repositories by the presence of .git directories.
+            # repositories via any ".git" entry (a directory for normal
+            # clones, or a file for worktree/submodule-style checkouts), so
+            # match by name rather than restricting to directories.
+            # Prune matched ".git" entries so find does not descend into
+            # their (potentially large) object/refs stores while counting.
             path="$1"
             if [ -d "$path" ]; then
-              find "$path" -type d -name '.git' 2>/dev/null | wc -l | tr -d ' '
+              find "$path" -name '.git' -prune -print 2>/dev/null \
+                | wc -l | tr -d ' '
             else
               echo 0
             fi

--- a/.github/workflows/reporting-production.yaml
+++ b/.github/workflows/reporting-production.yaml
@@ -397,27 +397,65 @@ jobs:
           CFG_PROJECT: ${{ steps.config.outputs.project }}
           GERRIT_OUTCOME: ${{ steps.clone-gerrit.outcome }}
           GITHUB_OUTCOME: ${{ steps.clone-github.outcome }}
+          GERRIT_SUCCESS: ${{ steps.clone-gerrit.outputs.success-count }}
+          GERRIT_TOTAL: ${{ steps.clone-gerrit.outputs.total-count }}
+          GITHUB_SUCCESS: ${{ steps.clone-github.outputs.success-count }}
+          GITHUB_TOTAL: ${{ steps.clone-github.outputs.total-count }}
         # yamllint disable rule:line-length
         run: |
-          # Determine which clone step ran and check its outcome
+          # Validate BOTH the clone step outcome AND that it actually
+          # produced repositories. A "success" outcome with zero cloned
+          # repositories indicates a transient discovery/clone failure (for
+          # example, Gerrit under heavy bot/scraper load, or a base-URL
+          # discovery fallback to a wrong path). Treat that as a gating
+          # failure so the job can simply be re-run, rather than continuing
+          # to generate an empty report that would overwrite good data on
+          # GitHub Pages.
+
+          count_local_repos() {
+            # Count git repositories present on disk under the given path.
+            # This mirrors what the report tool consumes: it discovers
+            # repositories by the presence of .git directories.
+            path="$1"
+            if [ -d "$path" ]; then
+              find "$path" -type d -name '.git' 2>/dev/null | wc -l | tr -d ' '
+            else
+              echo 0
+            fi
+          }
+
           if [ -n "${CFG_GERRIT}" ]; then
             # Gerrit project
             if [ "${GERRIT_OUTCOME}" != "success" ]; then
-              echo "::error::Failed to clone Gerrit repositories for ${CFG_PROJECT}"
-              echo "::error::Gerrit server may be unavailable or decommissioned"
+              echo "::error::Failed to clone Gerrit repositories for ${CFG_PROJECT} (outcome: ${GERRIT_OUTCOME})"
+              echo "::error::Gerrit server may be unavailable or under heavy load; re-run this job to retry"
               exit 1
-            else
-              echo "✅ Successfully cloned Gerrit repositories"
             fi
+            on_disk="$(count_local_repos "./${CFG_GERRIT}")"
+            echo "ℹ️ Gerrit clone counts: success=${GERRIT_SUCCESS:-0} total=${GERRIT_TOTAL:-0} on_disk=${on_disk}"
+            if [ "${on_disk:-0}" -eq 0 ]; then
+              echo "::error::Clone reported success but produced 0 repositories for ${CFG_PROJECT}"
+              echo "::error::This usually indicates a transient Gerrit discovery/clone failure."
+              echo "::error::Re-run this job to retry; refusing to generate a report from empty data."
+              exit 1
+            fi
+            echo "✅ Successfully cloned Gerrit repositories (${on_disk} on disk)"
           elif [ -n "${CFG_GITHUB}" ]; then
             # GitHub-only project
             if [ "${GITHUB_OUTCOME}" != "success" ]; then
-              echo "::error::Failed to clone GitHub repositories for ${CFG_PROJECT}"
-              echo "::error::GitHub organization may be unavailable or inaccessible"
+              echo "::error::Failed to clone GitHub repositories for ${CFG_PROJECT} (outcome: ${GITHUB_OUTCOME})"
+              echo "::error::GitHub organization may be unavailable or inaccessible; re-run this job to retry"
               exit 1
-            else
-              echo "✅ Successfully cloned GitHub repositories"
             fi
+            on_disk="$(count_local_repos "./github.com/${CFG_GITHUB}")"
+            echo "ℹ️ GitHub clone counts: success=${GITHUB_SUCCESS:-0} total=${GITHUB_TOTAL:-0} on_disk=${on_disk}"
+            if [ "${on_disk:-0}" -eq 0 ]; then
+              echo "::error::Clone reported success but produced 0 repositories for ${CFG_PROJECT}"
+              echo "::error::This usually indicates a transient GitHub discovery/clone failure."
+              echo "::error::Re-run this job to retry; refusing to generate a report from empty data."
+              exit 1
+            fi
+            echo "✅ Successfully cloned GitHub repositories (${on_disk} on disk)"
           else
             echo "::error::Project has neither gerrit nor github configured"
             exit 1

--- a/.github/workflows/reporting-production.yaml
+++ b/.github/workflows/reporting-production.yaml
@@ -8,6 +8,14 @@ name: "📊 Production Reports"
 on:
   workflow_dispatch:
     inputs:
+      projects:
+        description: >-
+          Projects to run (comma/space separated slugs; empty = all
+          active projects). Use this to selectively re-run reports,
+          e.g. "onap" or "onap, o-ran-sc".
+        required: false
+        type: string
+        default: ''
       debug:
         description: 'Enable debug output'
         required: false
@@ -255,28 +263,67 @@ jobs:
         shell: bash
         env:
           ACTIVE_PROJECTS_VAR: ${{ vars.ACTIVE_PROJECTS }}
+          SELECTED_PROJECTS: ${{ inputs.projects }}
+        # yamllint disable rule:line-length
         run: |
-          # Build matrix from ACTIVE_PROJECTS variable
-          # This job does NOT access any secrets
+          # Build matrix from ACTIVE_PROJECTS variable, optionally filtered
+          # by the workflow_dispatch "projects" input so a single report (or
+          # a subset) can be re-run on demand. This job does NOT access any
+          # secrets.
           active_projects="${ACTIVE_PROJECTS_VAR}"
+          selected="${SELECTED_PROJECTS}"
 
           if [ -z "$active_projects" ]; then
             echo "::error::ACTIVE_PROJECTS variable is not set"
             exit 1
           fi
 
-          matrix=$(echo "{\"slug\": $active_projects}" | jq -c .)
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          # Normalise the requested slugs: accept comma and/or whitespace
+          # separation, lower-case for case-insensitive matching, drop
+          # blank entries. Done entirely in jq to avoid shell word-splitting.
+          requested=$(jq -nc --arg s "$selected" \
+            '[$s | ascii_downcase | splits("[,[:space:]]+")] | map(select(length > 0))')
 
-          project_count=$(echo "$active_projects" | jq '. | length')
+          if [ "$(echo "$requested" | jq 'length')" -eq 0 ]; then
+            # No filter supplied (scheduled run or empty input): run all.
+            filtered="$active_projects"
+            echo "No project filter supplied; running all active projects"
+          else
+            echo "Requested project slug(s): $(echo "$requested" | jq -r 'join(", ")')"
+
+            # Reject any requested slug that is not an active project.
+            invalid=$(jq -nc --argjson active "$active_projects" \
+              --argjson req "$requested" \
+              '($active | map(ascii_downcase)) as $a
+               | [$req[] | . as $r | select(($a | index($r)) == null)]')
+            if [ "$(echo "$invalid" | jq 'length')" -ne 0 ]; then
+              echo "::error::Unknown project slug(s): $(echo "$invalid" | jq -r 'join(", ")')"
+              echo "::error::Available slugs: $(echo "$active_projects" | jq -r 'join(", ")')"
+              exit 1
+            fi
+
+            # Keep the canonical slug spelling/order from ACTIVE_PROJECTS.
+            filtered=$(echo "$active_projects" | jq -c --argjson req "$requested" \
+              '[.[] | select((ascii_downcase) as $s | ($req | index($s)) != null)]')
+          fi
+
+          project_count=$(echo "$filtered" | jq '. | length')
+          if [ "$project_count" -eq 0 ]; then
+            echo "::error::No projects selected to run"
+            exit 1
+          fi
+
+          matrix=$(echo "{\"slug\": $filtered}" | jq -c .)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
           {
             echo "### Projects to Process"
             echo ""
             echo "**Total projects:** $project_count"
             echo ""
-            echo "$active_projects" | jq -r '.[] | "- \(.)"'
+            echo "$filtered" | jq -r '.[] | "- \(.)"'
           } >> "$GITHUB_STEP_SUMMARY"
+        # yamllint enable rule:line-length
 
   analyze:
     name: "${{ matrix.slug }}"

--- a/src/cli/arguments.py
+++ b/src/cli/arguments.py
@@ -181,6 +181,15 @@ For more information, see docs/CLI_REFERENCE.md
         help="Enable caching of git metrics to speed up subsequent runs",
     )
     behavior.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help=(
+            "Allow report generation when no repositories are found. By "
+            "default an empty repositories directory is treated as an error, "
+            "since it usually indicates an upstream clone failure."
+        ),
+    )
+    behavior.add_argument(
         "--workers",
         type=int,
         metavar="N",

--- a/src/lf_releng_project_reporting/cli.py
+++ b/src/lf_releng_project_reporting/cli.py
@@ -193,6 +193,16 @@ def generate(
             rich_help_panel="Validation",
         ),
     ] = False,
+    allow_empty: Annotated[
+        bool,
+        typer.Option(
+            "--allow-empty",
+            help="Allow report generation when no repositories are found "
+            "(default: fail, since an empty result usually means an upstream "
+            "clone failure)",
+            rich_help_panel="Validation",
+        ),
+    ] = False,
     # Version
     _version: Annotated[
         bool | None,
@@ -265,6 +275,7 @@ def generate(
         validate_only=dry_run,
         log_level=None,
         github_token_env=github_token_env,
+        allow_empty=allow_empty,
     )
 
     # Set log level based on verbosity

--- a/src/lf_releng_project_reporting/cli.py
+++ b/src/lf_releng_project_reporting/cli.py
@@ -13,7 +13,7 @@ This module provides a rich, user-friendly command-line interface with:
 """
 
 import sys
-from enum import Enum
+from enum import Enum, StrEnum
 from pathlib import Path
 from typing import Annotated
 
@@ -34,7 +34,7 @@ app = typer.Typer(
 console = Console()
 
 
-class OutputFormat(str, Enum):
+class OutputFormat(StrEnum):
     """Output format options."""
 
     JSON = "json"
@@ -43,7 +43,7 @@ class OutputFormat(str, Enum):
     ALL = "all"
 
 
-class InitTemplate(str, Enum):
+class InitTemplate(StrEnum):
     """Configuration template options."""
 
     MINIMAL = "minimal"

--- a/src/lf_releng_project_reporting/exceptions.py
+++ b/src/lf_releng_project_reporting/exceptions.py
@@ -69,6 +69,19 @@ class RepositoryError(ReportingToolError):
     pass
 
 
+class NoRepositoriesError(ReportingToolError):
+    """Raised when no repositories are found to analyze.
+
+    This typically indicates that an upstream clone step produced an empty
+    working directory (for example, a transient Gerrit discovery/clone
+    failure). Generating a report from zero repositories yields empty,
+    misleading output, so this is treated as a hard error that callers
+    (and CI jobs) can retry.
+    """
+
+    pass
+
+
 class CollectionError(ReportingToolError):
     """Raised when data collection fails."""
 

--- a/src/lf_releng_project_reporting/main.py
+++ b/src/lf_releng_project_reporting/main.py
@@ -37,6 +37,7 @@ from lf_releng_project_reporting.config import (
     load_configuration,
     save_resolved_config,
 )
+from lf_releng_project_reporting.exceptions import NoRepositoriesError
 from lf_releng_project_reporting.reporter import RepositoryReporter
 from util.github_org import determine_github_org
 from util.zip_bundle import create_report_bundle
@@ -462,7 +463,8 @@ def main(args=None) -> int:
         reporter = RepositoryReporter(config, logger, api_stats)
 
         # Analyze repositories
-        report_data = reporter.analyze_repositories(args.repos_path)
+        allow_empty = bool(getattr(args, "allow_empty", False))
+        report_data = reporter.analyze_repositories(args.repos_path, allow_empty=allow_empty)
 
         # Generate outputs
         _write_report_outputs(reporter, report_data, config, args, project_output_dir, logger)
@@ -472,6 +474,12 @@ def main(args=None) -> int:
     except KeyboardInterrupt:
         print("\n❌ Operation cancelled by user", file=sys.stderr)
         return 130
+    except NoRepositoriesError as e:
+        # Empty working directory: almost always a transient upstream clone
+        # failure. Fail loudly with a retryable exit code rather than emitting
+        # an empty report that could overwrite previously good output.
+        print(f"❌ {e}", file=sys.stderr)
+        return 1
     except Exception as e:
         print(f"❌ Unexpected error: {e}", file=sys.stderr)
         if args is not None and hasattr(args, "verbose") and args.verbose:

--- a/src/lf_releng_project_reporting/reporter.py
+++ b/src/lf_releng_project_reporting/reporter.py
@@ -121,9 +121,10 @@ class RepositoryReporter:
         Main analysis workflow.
 
         Coordinates all phases of repository analysis:
-        1. Clone info-master for additional context
-        2. Initialize report data structure
-        3. Discover all repositories
+        1. Discover all repositories (fails fast if none are found, before
+           any network work, unless ``allow_empty`` is set)
+        2. Clone info-master for additional context
+        3. Initialize report data structure
         4. Analyze repositories in parallel
         5. Aggregate data across repositories
         6. Generate Jenkins allocation summary
@@ -166,8 +167,9 @@ class RepositoryReporter:
                 f"No repositories found to analyze under '{repos_path_abs}'. "
                 "This usually indicates an upstream clone failure (for example, "
                 "a transient Gerrit discovery/clone problem). Re-run the clone "
-                "and report generation, or pass allow_empty=True if an empty "
-                "result is expected."
+                "and report generation, or explicitly allow an empty result "
+                "(pass --allow-empty on the CLI, or allow_empty=True via the "
+                "Python API)."
             )
 
         # Clone info-master repository for additional context
@@ -349,7 +351,9 @@ class RepositoryReporter:
             for state, count in orphaned_summary["by_state"].items():
                 self.logger.info(f"  - {count} jobs for {state} projects")
 
-    def generate_reports(self, repos_path: Path, output_dir: Path) -> dict[str, Path]:
+    def generate_reports(
+        self, repos_path: Path, output_dir: Path, allow_empty: bool = False
+    ) -> dict[str, Path]:
         """
         Generate complete reports (JSON, Markdown, HTML, ZIP).
 
@@ -365,15 +369,22 @@ class RepositoryReporter:
         Args:
             repos_path: Path to directory containing repositories
             output_dir: Path to output directory for generated reports
+            allow_empty: Forwarded to :meth:`analyze_repositories`. When
+                ``False`` (the default), a hard error is raised if no
+                repositories are discovered under ``repos_path``.
 
         Returns:
             Dictionary mapping output type to file path for all generated files
+
+        Raises:
+            NoRepositoriesError: If no repositories are discovered and
+                ``allow_empty`` is ``False``.
         """
         # Ensure output directory exists
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Analyze repositories
-        report_data = self.analyze_repositories(repos_path)
+        report_data = self.analyze_repositories(repos_path, allow_empty=allow_empty)
 
         project = self.config["project"]
         json_path = output_dir / "report_raw.json"

--- a/src/lf_releng_project_reporting/reporter.py
+++ b/src/lf_releng_project_reporting/reporter.py
@@ -31,6 +31,7 @@ from typing import Any, cast
 from lf_releng_project_reporting.aggregators import DataAggregator
 from lf_releng_project_reporting.collectors import GitDataCollector, INFOYamlCollector
 from lf_releng_project_reporting.config import save_resolved_config
+from lf_releng_project_reporting.exceptions import NoRepositoriesError
 from lf_releng_project_reporting.features import FeatureRegistry
 from rendering.renderer import ModernReportRenderer
 from util.git import safe_git_command
@@ -115,7 +116,7 @@ class RepositoryReporter:
             self.info_master_temp_dir = None
             return None
 
-    def analyze_repositories(self, repos_path: Path) -> dict[str, Any]:
+    def analyze_repositories(self, repos_path: Path, allow_empty: bool = False) -> dict[str, Any]:
         """
         Main analysis workflow.
 
@@ -129,9 +130,18 @@ class RepositoryReporter:
 
         Args:
             repos_path: Path to directory containing repositories to analyze
+            allow_empty: When ``False`` (the default), a hard error is raised
+                if no repositories are discovered under ``repos_path``. This
+                guards against generating an empty, misleading report when an
+                upstream clone step failed transiently. Set to ``True`` only
+                when an empty result is genuinely acceptable.
 
         Returns:
             Complete report data dictionary with all analysis results
+
+        Raises:
+            NoRepositoriesError: If no repositories are discovered and
+                ``allow_empty`` is ``False``.
         """
         # Resolve to absolute path for consistent handling
         repos_path_abs = repos_path.resolve()
@@ -141,6 +151,24 @@ class RepositoryReporter:
         # This is used to filter INFO.yaml data to only the relevant server
         gerrit_server = self._determine_gerrit_server(repos_path_abs)
         self.logger.info(f"Detected Gerrit server: {gerrit_server}")
+
+        # Discover repositories up front and fail fast when the working
+        # directory is empty. An empty result almost always means an upstream
+        # clone step produced no repositories (for example, a transient Gerrit
+        # discovery/clone failure). Continuing would generate an empty report
+        # that could overwrite previously good output, so raise a retryable
+        # error before doing any further (network) work, unless the caller
+        # explicitly opts in via allow_empty.
+        repo_dirs = self._discover_repositories(repos_path_abs)
+        self.logger.info(f"Found {len(repo_dirs)} repositories to analyze")
+        if not repo_dirs and not allow_empty:
+            raise NoRepositoriesError(
+                f"No repositories found to analyze under '{repos_path_abs}'. "
+                "This usually indicates an upstream clone failure (for example, "
+                "a transient Gerrit discovery/clone problem). Re-run the clone "
+                "and report generation, or pass allow_empty=True if an empty "
+                "result is expected."
+            )
 
         # Clone info-master repository for additional context
         # This is cloned to a temporary directory to avoid it appearing in the report
@@ -161,10 +189,6 @@ class RepositoryReporter:
 
         # Update git collector with repos_path for relative path calculation
         self.git_collector.repos_path = repos_path_abs
-
-        # Find all repository directories
-        repo_dirs = self._discover_repositories(repos_path_abs)
-        self.logger.info(f"Found {len(repo_dirs)} repositories to analyze")
 
         # Analyze repositories (with concurrency)
         repo_metrics = self._analyze_repositories_parallel(repo_dirs)

--- a/tests/test_main_no_repositories.py
+++ b/tests/test_main_no_repositories.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""
+Tests for main() exit-code handling of the "no repositories" condition.
+
+When repository discovery yields nothing, main() must exit with a non-zero,
+retryable exit code (1) and must NOT produce a report. This protects
+downstream consumers (for example, the GitHub Pages publish step) from having
+good reports overwritten with empty output after a transient clone failure.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+import lf_releng_project_reporting.main as main_module
+from lf_releng_project_reporting.exceptions import NoRepositoriesError
+
+
+class _RaisingReporter:
+    """Stand-in reporter whose analysis always reports zero repositories."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def analyze_repositories(self, repos_path, allow_empty=False):
+        raise NoRepositoriesError(f"No repositories found to analyze under '{repos_path}'.")
+
+
+@pytest.fixture
+def patched_main(monkeypatch, tmp_path):
+    """Neutralise config loading/logging so only exit-code mapping is tested."""
+    monkeypatch.setattr(
+        main_module, "load_configuration", lambda project, config_dir: {"project": project}
+    )
+    monkeypatch.setattr(
+        main_module, "_prepare_run_config", lambda args, config: logging.getLogger("test")
+    )
+    monkeypatch.setattr(main_module, "write_config_to_step_summary", lambda *a, **k: None)
+    monkeypatch.setattr(main_module, "RepositoryReporter", _RaisingReporter)
+
+    return SimpleNamespace(
+        project="test-project",
+        repos_path=tmp_path / "gerrit.onap.org",
+        config_dir=tmp_path / "configuration",
+        output_dir=tmp_path / "reports",
+        validate_only=False,
+        verbose=0,
+        allow_empty=False,
+    )
+
+
+def test_main_returns_error_exit_code_on_no_repositories(patched_main):
+    """main() returns exit code 1 (retryable) when no repositories are found."""
+    exit_code = main_module.main(patched_main)
+    assert exit_code == 1
+
+
+def test_main_no_repositories_is_retryable(patched_main):
+    """The returned exit code is classified as retryable for CI re-runs."""
+    from cli.exit_codes import should_retry
+
+    exit_code = main_module.main(patched_main)
+    assert should_retry(exit_code) is True

--- a/tests/unit/test_reporter_empty_guard.py
+++ b/tests/unit/test_reporter_empty_guard.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""
+Tests for the "no repositories" fast-fail guard in RepositoryReporter.
+
+An empty working directory almost always means an upstream clone step failed
+transiently (for example, a Gerrit discovery/clone problem). Generating a
+report from zero repositories produces empty, misleading output that can
+overwrite previously good data. These tests lock in the behaviour that such a
+situation is a hard, retryable error by default, and that callers can opt out
+via ``allow_empty``.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from lf_releng_project_reporting.exceptions import NoRepositoriesError
+from lf_releng_project_reporting.reporter import RepositoryReporter
+
+
+def _make_reporter() -> RepositoryReporter:
+    """Build a reporter with INFO.yaml collection disabled for offline tests."""
+    config = {"project": "test-project", "info_yaml": {"enabled": False}}
+    logger = logging.getLogger(__name__)
+    return RepositoryReporter(config, logger)
+
+
+class TestEmptyRepositoriesGuard:
+    """Behaviour when no repositories are discovered under repos_path."""
+
+    def test_raises_when_repos_dir_is_empty(self, tmp_path: Path):
+        """An empty repos directory raises NoRepositoriesError by default."""
+        repos_path = tmp_path / "gerrit.onap.org"
+        repos_path.mkdir()
+
+        reporter = _make_reporter()
+
+        with pytest.raises(NoRepositoriesError):
+            reporter.analyze_repositories(repos_path)
+
+    def test_error_message_is_actionable(self, tmp_path: Path):
+        """The raised error explains the likely cause and how to recover."""
+        repos_path = tmp_path / "gerrit.onap.org"
+        repos_path.mkdir()
+
+        reporter = _make_reporter()
+
+        with pytest.raises(NoRepositoriesError) as exc_info:
+            reporter.analyze_repositories(repos_path)
+
+        message = str(exc_info.value)
+        assert "No repositories found" in message
+        assert "clone" in message.lower()
+
+    def test_guard_runs_before_info_master_clone(self, tmp_path: Path, monkeypatch):
+        """The guard fails fast, before any (network) info-master clone."""
+        repos_path = tmp_path / "gerrit.onap.org"
+        repos_path.mkdir()
+
+        reporter = _make_reporter()
+
+        def _fail_if_called():
+            raise AssertionError("info-master clone must not run for empty repos")
+
+        monkeypatch.setattr(reporter, "_clone_info_master_repo", _fail_if_called)
+
+        with pytest.raises(NoRepositoriesError):
+            reporter.analyze_repositories(repos_path)
+
+    def test_allow_empty_skips_guard(self, tmp_path: Path, monkeypatch):
+        """With allow_empty=True an empty directory is analysed without error."""
+        repos_path = tmp_path / "gerrit.onap.org"
+        repos_path.mkdir()
+
+        reporter = _make_reporter()
+
+        # Keep the analysis fully offline: no info-master clone, no INFO.yaml.
+        monkeypatch.setattr(reporter, "_clone_info_master_repo", lambda: None)
+        monkeypatch.setattr(
+            reporter,
+            "_collect_info_yaml_data",
+            lambda *args, **kwargs: None,
+        )
+
+        report_data = reporter.analyze_repositories(repos_path, allow_empty=True)
+
+        assert report_data["repositories"] == []
+
+    def test_does_not_raise_when_repositories_present(self, tmp_path: Path, monkeypatch):
+        """A populated directory passes the guard (no false positive)."""
+        repos_path = tmp_path / "gerrit.onap.org"
+        (repos_path / "example-repo" / ".git").mkdir(parents=True)
+
+        reporter = _make_reporter()
+
+        # Stub out the heavy/network stages; we only care that the guard did
+        # not raise for a directory that contains at least one repository.
+        monkeypatch.setattr(reporter, "_clone_info_master_repo", lambda: None)
+        monkeypatch.setattr(
+            reporter,
+            "_collect_info_yaml_data",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            reporter,
+            "_analyze_repositories_parallel",
+            lambda repo_dirs: [],
+        )
+
+        # Should not raise NoRepositoriesError.
+        report_data = reporter.analyze_repositories(repos_path)
+        assert "repositories" in report_data


### PR DESCRIPTION
## Summary

Two related reliability improvements to the reporting infrastructure,
prompted by the ONAP production report rendering nearly empty (0
repositories, all Jenkins jobs "orphaned", no CI/CD status) and then
overwriting the previously good report on GitHub Pages.

### Root cause

A transient Gerrit discovery/clone failure produced an empty working
directory, but the clone step still exited `success`. Nothing
downstream detected the empty directory, so the tool generated an empty
report that was published over good data. The failing ONAP job could
have simply been re-run had it failed loudly — instead it "succeeded"
with flawed output.

## Changes

### 1. Fail fast when the clone yields no repositories (`Fix`)

- **Report tool:** `analyze_repositories()` now discovers repositories
  up front and raises `NoRepositoriesError` before any further (network)
  work when none are found. `main()` maps this to a non-zero, retryable
  exit code, so an empty report is never generated. A new `--allow-empty`
  flag preserves the previous behaviour for the rare cases where an
  empty result is genuinely intended.
- **Workflows:** the "Check clone status" gate in
  `reporting-production` and `reporting-previews` now validates that the
  clone actually produced repositories on disk (matching what the tool
  consumes via `.git` discovery), not just the step outcome. Zero
  repositories is treated as a gating failure with an actionable,
  retry-oriented message.
- **Tests:** new unit tests cover the guard (raise by default, honour
  `allow_empty`, no false positives, fail before the info-master clone)
  and the `main()` exit-code mapping.

### 2. Selectively run projects on manual dispatch (`Feat`)

- New `projects` `workflow_dispatch` input filters the build matrix to a
  chosen subset of slugs (comma/space separated, case-insensitive,
  canonical spelling preserved). Empty (the default, and every scheduled
  run) processes all active projects; unknown slugs fail the matrix
  build with a list of valid options.
- Combined with the existing `skip_artifact_transfer` /
  `skip_pages_update` inputs, this makes it possible to re-run a single
  broken report (e.g. `onap`) and refresh its published page and
  artifacts.

### GitHub Pages safety for subset runs

Verified that a subset run updates **only** the selected projects: the
`publish` job checks out the full existing `gh-pages` tree, overwrites
only the re-run slug directories, and regenerates the index from the
whole tree (`find . -name report.html`) so every project remains listed.
Commits are additive (no `git rm`), so untouched projects are preserved.
If a re-run's clone is empty again, `analyze` fails, no report artifact
is produced, and the publish/commit steps are skipped — the good page is
never overwritten.

## Validation

- Targeted test suite: 1441 passed, 20 network-skipped; 7 new tests
  pass.
- `prek` (ruff, ruff-format, mypy, basedpyright, yamllint, actionlint
  incl. embedded shellcheck, GitHub workflow validation) — all pass.
- Zizmor `--persona auditor` on both modified workflows — zero findings.
- Matrix-filter jq logic verified against empty / single / subset /
  case-insensitive / invalid inputs.
