### PR TITLE
Fix: clarify scope in Slack failure notification

### DIFF
--- a/.github/workflows/reporting-production.yaml
+++ b/.github/workflows/reporting-production.yaml
@@ -1382,17 +1382,26 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         # yamllint disable rule:line-length
         run: |
-          # Query the GitHub API for matrix job results
+          # Query the GitHub API for matrix job results.
+          # Matrix legs are named after the project slug, so the regex
+          # below isolates them from the pipeline jobs (which all carry
+          # capitals and spaces, e.g. "Publish GitHub Pages").
           echo "Checking matrix job results..."
 
-          FAILED_PROJECTS=$(gh api \
+          ALL_PROJECTS=$(gh api \
             "/repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
             --paginate \
-            --jq '.jobs[] | select(.conclusion != "success" and .conclusion != null and .conclusion != "skipped" and (.name | test("^[a-z][a-z0-9-]*$"))) | .name' \
+            --jq '.jobs[] | select(.name | test("^[a-z][a-z0-9-]*$")) | "\(.name)\t\(.conclusion // "pending")"' \
             | sort)
 
+          FAILED_PROJECTS=$(echo "$ALL_PROJECTS" \
+            | awk -F'\t' '$2 != "success" && $2 != "skipped" && $2 != "pending" {print $1}')
+
+          TOTAL_COUNT=$(echo "$ALL_PROJECTS" | grep -c . || true)
+          FAILED_COUNT=$(echo "$FAILED_PROJECTS" | grep -c . || true)
+
           if [ -n "$FAILED_PROJECTS" ]; then
-            echo "Failed projects:"
+            echo "Projects without a report (${FAILED_COUNT} of ${TOTAL_COUNT}):"
             while IFS= read -r P; do
               [ -z "$P" ] && continue
               echo "  - ${P}"
@@ -1401,6 +1410,17 @@ jobs:
             echo "Could not determine specific failed projects"
             FAILED_PROJECTS="(check workflow run for details)"
           fi
+
+          # Annotate the Analyze stage so readers can tell a single
+          # missing project apart from a wholesale matrix collapse.
+          # Worded as "no report" rather than "failed" because the
+          # filter above deliberately counts cancelled and timed-out
+          # legs too: those produce no report either.
+          detail=""
+          if [ "$FAILED_COUNT" -gt 0 ] && [ "$TOTAL_COUNT" -gt 0 ]; then
+            detail=" (no report from ${FAILED_COUNT} of ${TOTAL_COUNT} projects)"
+          fi
+          echo "detail=${detail}" >> "$GITHUB_OUTPUT"
 
           # Join project names into single line for YAML safety
           ESCAPED_PROJECTS=$(echo "$FAILED_PROJECTS" | paste -sd ',' - | sed 's/,/, /g')
@@ -1447,17 +1467,24 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "*Failed projects:*\n```${{ steps.failed-projects.outputs.list || 'N/A (no matrix project failures detected)' }}```"
+                  text: "*Projects with no report this run:*\n```${{ steps.failed-projects.outputs.list || 'N/A (no matrix project failures detected)' }}```"
               - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "*Pipeline stages* _(workflow-wide, not per-project)_"
                 fields:
                   - type: "mrkdwn"
                     text: "*Validate:* ${{ steps.workflow-status.outputs.validate_result }}"
                   - type: "mrkdwn"
-                    text: "*Analyze:* ${{ steps.workflow-status.outputs.analyze_result }}"
+                    text: "*Analyze:* ${{ steps.workflow-status.outputs.analyze_result }}${{ steps.failed-projects.outputs.detail }}"
                   - type: "mrkdwn"
                     text: "*Publish:* ${{ steps.workflow-status.outputs.publish_result }}"
                   - type: "mrkdwn"
                     text: "*Artifact Transfer:* ${{ steps.workflow-status.outputs.copy_result }}"
+              - type: "context"
+                elements:
+                  - type: "mrkdwn"
+                    text: "Publish and Artifact Transfer cover the projects that did produce reports; they succeed even when an individual project fails."
               - type: "context"
                 elements:
                   - type: "mrkdwn"


### PR DESCRIPTION
## Problem

The Slack failure notification mixes two different scopes without signalling the change of subject:

```
Failed projects:
  lfbroadband              <- project-scoped

Validate: success          Analyze: failure
Publish: success           Artifact Transfer: success   <- workflow-scoped
```

A reader carries the `lfbroadband` context downward and reads *"Publish: success"* as *"lfbroadband was published"*. That reading is false.

Every field is individually correct. `publish` and `copy-to-artifacts-repo` run with `if: always()` and ship whatever artifacts exist — by design, per the comment at the `publish` job:

> Whatever artifacts were produced should still be published rather than discarded on account of one transient matrix problem.

So they legitimately report `success` while one matrix leg fails. The defect is presentational, not logical.

## Approach

Deliberately **not** suppressing the stage grid when a project fails. Doing so would lose real signal — if `Publish` also failed you would want to see it, and you could no longer distinguish "one project failed but everything else shipped" from "the whole pipeline collapsed". Relabelling for scope is the smaller fix.

## Changes

- Grid is now headed **"Pipeline stages _(workflow-wide, not per-project)_"**.
- `Analyze` is annotated with a count of projects that produced no report, e.g. `failure (no report from 1 of 7 projects)`.
- Added a context footnote explaining why Publish and Artifact Transfer can succeed alongside a failed project.
- Renamed **"Failed projects"** to **"Projects with no report this run"** — describes the user-visible consequence rather than an internal job state.
- The jobs API query now collects every matrix leg with its conclusion in a single pass, so the list and both counts derive from one call.

### A note on "no report" vs "failed"

The filter counts any leg that is not `success`, `skipped` or still pending — so `cancelled` and `timed_out` are included. That is intentional: those leave a project without a report just as a `failure` does, and the notification should surface them. The wording therefore says *"no report"* throughout rather than *"failed"*, and there is a comment in the workflow recording why, so the filter doesn't get narrowed later to match looser prose.

## Before / after

Given today's run (one project of seven producing no report):

| | Before | After |
|---|---|---|
| Project line | `Failed projects: lfbroadband` | `Projects with no report this run: lfbroadband` |
| Analyze | `failure` | `failure (no report from 1 of 7 projects)` |
| Grid heading | *(none)* | `Pipeline stages (workflow-wide, not per-project)` |

## Validation

- Counting logic exercised against five cases — single failure, all failed, none failed, `cancelled`/`pending` mix, and empty input. No unbound-variable or divide-by-zero edges; `grep -c` returning exit 1 on zero matches is handled.
- `prek run --files .github/workflows/reporting-production.yaml` — all hooks pass.
- `zizmor --persona auditor` — **no findings**.

Not exercised end-to-end against a live Slack workspace; the payload change is Block Kit only (a `section` block carrying both `text` and `fields`, which is valid).

## Related

Surfaced while investigating the recurring `lfbroadband` failures. Companion PR #274 addresses the more substantive issue found alongside this: published reports for a failing project go silently stale on GitHub Pages.
