### PR TITLE
CI: Bump pypi-publish-action to v0.2.0

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: 'Test PyPI publishing'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
         with:
           environment: development
           tag: ${{ needs.release.outputs.tag }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: 'PyPI release'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
         with:
           environment: production
           tag: ${{ needs.release.outputs.tag }}


### PR DESCRIPTION
## Summary

Releases have been failing at the Test PyPI step since hatchling started emitting
`Metadata-Version: 2.5`. The publish backend bundled with `pypi-publish-action`
v0.1.9 carries twine 6.2.0, which rejects that metadata version outright:

```
ERROR    InvalidDistribution: Invalid distribution metadata: '2.5' is not a
         valid metadata version
```

v0.3.0 built, tested, attached its artefacts and promoted its GitHub release, but
never reached either PyPI instance
([run 32184173809](https://github.com/lfreleng-actions/project-reporting-tool/actions/runs/32184173809)).

v0.2.0 of the action bumps the backend to `gh-action-pypi-publish` v1.11.11,
which ships twine 7.0.0 and understands metadata 2.5.

## Change

Both publish steps in `.github/workflows/build-test-release.yaml`:

```diff
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
```

`276603f5d72b11427755ef139c6fb80489cec5d9` is the **commit** SHA behind the
annotated `v0.2.0` tag (the tag object `8798fe4e…` is deliberately not used, as
`uses:` requires a commit SHA). This is the same pin already landed in
`github-security-report-action` (#111).

Raised by hand rather than waiting for Dependabot, whose seven-day cooldown would
hold the bump back for another four days and leave releases broken until then.

## v0.3.0 has been published manually

So that the tagged release is not left stranded, the artefacts from the failed run
were downloaded and uploaded by hand with twine 7.0.0, after verifying they are
byte-identical to what the failed job attempted to publish:

| Artefact | SHA256 |
| --- | --- |
| `lf_releng_project_reporting-0.3.0-py3-none-any.whl` | `c7183dc12f989a7655cba1dd0aacb4a6d8d028dee76af46760696566ac281829` |
| `lf_releng_project_reporting-0.3.0.tar.gz` | `3f06a5b9d02902421bd37306783853aa42536486ffda3ae5f84e4a328876d1e8` |

Both are now live on [PyPI](https://pypi.org/project/lf-releng-project-reporting/0.3.0/)
and [Test PyPI](https://test.pypi.org/project/lf-releng-project-reporting/0.3.0/).
Attestations were skipped for that manual upload; the next tagged release will
publish them normally through this workflow.

## Validation

`twine check` passes on both artefacts under twine 7.0.0 and fails under 6.2.0,
confirming the backend version is the sole cause. The next release tag exercises
the changed steps end to end.
