### PR TITLE
Fix(tests): Stop the wizard test writing into the repo

### DIFF
--- a/tests/test_cli/test_wizard.py
+++ b/tests/test_cli/test_wizard.py
@@ -210,11 +210,17 @@ class TestCreateConfigFromTemplate:
         assert config["project"] == "test-project"
         assert "performance" in config
 
-    def test_create_config_auto_path(self, tmp_path):
+    def test_create_config_auto_path(self, tmp_path, monkeypatch):
         """Test creating config with automatic path."""
-        with patch("pathlib.Path.cwd", return_value=tmp_path):
-            result = create_config_from_template("test-project", "minimal")
-            assert "config/test-project.yaml" in result
+        # The default path is relative, so the working directory has to move:
+        # patching Path.cwd() would not redirect the write, and the file would
+        # land in the checkout it was run from.
+        monkeypatch.chdir(tmp_path)
+
+        result = create_config_from_template("test-project", "minimal")
+
+        assert "config/test-project.yaml" in result
+        assert (tmp_path / "config" / "test-project.yaml").exists()
 
     def test_create_config_creates_directories(self, tmp_path):
         """Test that config creation creates parent directories."""


### PR DESCRIPTION
## Summary

Every full test run left `config/test-project.yaml` modified in the working tree —
its SPDX header stripped and its indentation rewritten:

```diff
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2025 The Linux Foundation
----
 project: test-project
 time_windows:
-    reporting_window_days: 365
+  reporting_window_days: 365
```

## Root cause

`create_config_from_template()` builds its default destination as the **relative**
path `config/{project}.yaml`, which resolves against the process working
directory:

```python
if not output_path:
    output_path = f"config/{project}.yaml"
```

`test_create_config_auto_path` exercised that default and tried to isolate it with
`patch("pathlib.Path.cwd", return_value=tmp_path)` — but the function never calls
`Path.cwd()`, so the patch redirected nothing. The write escaped the temporary
directory and landed on the tracked `config/test-project.yaml` in whichever
checkout the suite ran from.

It was the only test that omitted `output_path`; every other call site passes an
explicit path under `tmp_path`.

## Fix

Move the working directory with `monkeypatch.chdir(tmp_path)`, which is what a
relative path actually follows, and assert the file lands where it should rather
than only checking the returned string:

```python
monkeypatch.chdir(tmp_path)

result = create_config_from_template("test-project", "minimal")

assert "config/test-project.yaml" in result
assert (tmp_path / "config" / "test-project.yaml").exists()
```

This is a test-only change; `create_config_from_template` keeps its documented
relative-to-cwd behaviour.

## Validation

- `uv run pytest tests/test_cli/test_wizard.py -q` — 39 passed
- `git status` is clean after the run, where it previously showed
  `config/test-project.yaml` as modified
- The new `.exists()` assertion fails if the write ever escapes again
