### PR TITLE
Chore: Annotate bytecode caches for REUSE

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -16,3 +16,10 @@ precedence = "aggregate"
 SPDX-FileCopyrightText = "2025 The Linux Foundation"
 SPDX-License-Identifier = "Apache-2.0"
 SPDX-FileComment = "JSON configuration files (JSON format doesn't support comments)"
+
+[[annotations]]
+path = ["**/__pycache__/**"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 The Linux Foundation"
+SPDX-License-Identifier = "Apache-2.0"
+SPDX-FileComment = "Python bytecode caches: git-ignored build artefacts that REUSE still scans when they sit inside a directory git does not yet track"


### PR DESCRIPTION
## Summary

`reuse lint` fails on `__pycache__` contents when they sit inside a directory git
does not yet track — even though `.gitignore` covers `*.pyc` and `git check-ignore`
agrees:

```
$ git check-ignore -v src/util/newpkg/__pycache__/__init__.cpython-314.pyc
.gitignore:86:*.pyc     src/util/newpkg/__pycache__/__init__.cpython-314.pyc

$ prek run reuse --all-files
reuse lint...............................................................Failed
# MISSING COPYRIGHT AND LICENSING INFORMATION
* src/util/newpkg/__pycache__/__init__.cpython-314.pyc
```

Caches inside directories git already tracks (`src/api/__pycache__`, and so on)
are skipped correctly, so the failure only appears for newly created directories.

## Why it matters now

Splitting an oversized module into a package makes this routine: the new package
directory is untracked at the moment the pre-commit hook runs, so every stale
`.pyc` left inside it by a previous test run is reported as missing licensing
information, and the commit is blocked for reasons unrelated to the change. The
only workaround is remembering to delete the caches first.

## Change

Annotate `**/__pycache__/**` in `REUSE.toml`, so the caches carry the project's
licence declaration regardless of whether their directory is tracked:

```toml
[[annotations]]
path = ["**/__pycache__/**"]
precedence = "aggregate"
SPDX-FileCopyrightText = "2026 The Linux Foundation"
SPDX-License-Identifier = "Apache-2.0"
SPDX-FileComment = "Python bytecode caches: git-ignored build artefacts that REUSE still scans when they sit inside a directory git does not yet track"
```

This matches the approach already used in the sibling `aislop-scan-action`
repository.

## Validation

Reproduced and verified end to end by planting a `.pyc` inside an untracked
package directory:

- before the annotation: `reuse lint` **fails**, listing the `.pyc`
- after the annotation: `reuse lint` **passes**
- with the reproduction removed: `reuse lint` still **passes**
